### PR TITLE
Script updates

### DIFF
--- a/CheckHelp.ps1
+++ b/CheckHelp.ps1
@@ -1,7 +1,7 @@
 
-ipmo PSReadline
+Import-Module -Name PSReadline
 
-$about_topic = Get-Help about_PSReadline
+$about_topic = Get-Help -Name about_PSReadline
 
 $methods = [PSConsoleUtilities.PSConsoleReadLine].GetMethods('public,static') |
     Where-Object {
@@ -36,12 +36,12 @@ $methods.Name | ForEach-Object {
     }
 }
 
-$commonParameters = echo Debug Verbose OutVariable OutBuffer ErrorAction WarningAction ErrorVariable WarningVariable PipelineVariable
+$commonParameters = Write-Output Debug Verbose OutVariable OutBuffer ErrorAction WarningAction ErrorVariable WarningVariable PipelineVariable
 Get-Command -Type Cmdlet -Module PSReadline |
     ForEach-Object {
         $cmdletInfo = $_
         $cmdletName = $cmdletInfo.Name
-        $cmdletHelp = Get-Help -Detailed $cmdletName
+        $cmdletHelp = Get-Help -Name $cmdletName -Detailed
         $cmdletInfo.Parameters.Keys |
             ForEach-Object {
                 $parameterName = $_

--- a/CheckHelp.ps1
+++ b/CheckHelp.ps1
@@ -12,7 +12,7 @@ $methods = [PSConsoleUtilities.PSConsoleReadLine].GetMethods('public,static') |
             $parameters[1].ParameterType -eq [object]
     }
 
-foreach ($method in $methods)
+ForEach-Object ($method in $methods)
 {
     $parameters = $method.GetParameters()
     if ($parameters[0].Name -ne 'key' -or $parameters[1].Name -ne 'arg')

--- a/MakeRelease.ps1
+++ b/MakeRelease.ps1
@@ -28,7 +28,7 @@ $files = @('PSReadline\Changes.txt',
            'PSReadline\PSReadline.format.ps1xml',
            'PSReadline\bin\Release\PSReadline.dll')
 
-foreach ($file in $files)
+ForEach-Object ($file in $files)
 {
     Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir
 }
@@ -36,7 +36,7 @@ foreach ($file in $files)
 $files = @('PSReadline\en-US\about_PSReadline.help.txt',
            'PSReadline\en-US\PSReadline.dll-help.xml')
 
-foreach ($file in $files)
+ForEach-Object ($file in $files)
 {
     Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir\en-us
 }

--- a/MakeRelease.ps1
+++ b/MakeRelease.ps1
@@ -14,11 +14,11 @@ $targetDir = "${env:Temp}\PSReadline"
 
 if (Test-Path -Path $targetDir)
 {
-    Remove-Item -re $targetDir
+    rmdir -re $targetDir
 }
 
-$null = New-Item -Path $targetDir -ItemType directory
-$null = New-Item -Path $targetDir\en-US -ItemType directory
+$null = mkdir $targetDir
+$null = mkdir $targetDir\en-US
 
 $files = @('PSReadline\Changes.txt',
            'PSReadline\License.txt',
@@ -30,7 +30,7 @@ $files = @('PSReadline\Changes.txt',
 
 ForEach-Object ($file in $files)
 {
-    Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir
+    copy $PSScriptRoot\$file $targetDir
 }
 
 $files = @('PSReadline\en-US\about_PSReadline.help.txt',
@@ -38,7 +38,7 @@ $files = @('PSReadline\en-US\about_PSReadline.help.txt',
 
 ForEach-Object ($file in $files)
 {
-    Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir\en-us
+    copy $PSScriptRoot\$file $targetDir\en-us
 }
 
 $version = (Get-ChildItem -Path $targetDir\PSReadline.dll).VersionInfo.FileVersion
@@ -52,17 +52,17 @@ if (Get-Command -Name cpack -ea Ignore)
 
     if (Test-Path -Path $chocolateyDir\PSReadline)
     {
-        Remove-Item -Recurse -Path $chocolateyDir\PSReadline
+        rmdir -re $chocolateyDir\PSReadline
     }
 
     & $PSScriptRoot\Update-NuspecVersion.ps1 "$chocolateyDir\PSReadline.nuspec" $version
 
-    Copy-Item -Recurse -Path $targetDir -Destination $chocolateyDir\PSReadline
+    copy -re $targetDir $chocolateyDir\PSReadline
 
     cpack "$chocolateyDir\PSReadline.nuspec"
 }
 
-Remove-Item -Path $PSScriptRoot\PSReadline.zip -ea Ignore
+del $PSScriptRoot\PSReadline.zip -ea Ignore
 [System.IO.Compression.ZipFile]::CreateFromDirectory($targetDir, "$PSScriptRoot\PSReadline.zip")
 
 if ($Install)
@@ -71,16 +71,16 @@ if ($Install)
 
     if (!(Test-Path -Path $InstallDir))
     {
-        New-Item -force -Path $InstallDir -ItemType Directory
+        mkdir $InstallDir -Force
     }
 
     try
     {
         if (Test-Path -Path $InstallDir\PSReadline)
         {
-            Remove-Item -Recurse -force -Path $InstallDir\PSReadline -ea Stop
+            rmdir -re -force $InstallDir\PSReadline -ea Stop
         }
-        Copy-Item -Recurse -Path $targetDir -Destination $InstallDir
+        copy -re $targetDir ex$InstallDir
     }
     catch
     {

--- a/Update-ModuleManifest.ps1
+++ b/Update-ModuleManifest.ps1
@@ -5,15 +5,15 @@ param (
      [String] $Version
 )
 
-if ((Test-Path $FilePath -PathType Leaf) -ne $TRUE) {
+if ((Test-Path -Path $FilePath -PathType Leaf) -ne $TRUE) {
     Write-Error -Message ($FilePath + ' not found.') -Category InvalidArgument;
     exit 1;
 }
 
 #normalize path
-$FilePath = (Resolve-Path $FilePath).Path;
+$FilePath = (Resolve-Path -Path $FilePath).Path;
 
 $moduleVersionPattern = "ModuleVersion = '.*'";
 $newVersion = "ModuleVersion = '" + $Version + "'";
 
-(Get-Content $FilePath) | % {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content $FilePath;
+(Get-Content -Path $FilePath) | For-Each {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content -Path $FilePath;

--- a/Update-ModuleManifest.ps1
+++ b/Update-ModuleManifest.ps1
@@ -16,4 +16,4 @@ $FilePath = (Resolve-Path -Path $FilePath).Path;
 $moduleVersionPattern = "ModuleVersion = '.*'";
 $newVersion = "ModuleVersion = '" + $Version + "'";
 
-(Get-Content -Path $FilePath) | For-Each {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content -Path $FilePath;
+(Get-Content -Path $FilePath) | ForEach-Object {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content -Path $FilePath;

--- a/Update-NuspecVersion.ps1
+++ b/Update-NuspecVersion.ps1
@@ -5,15 +5,15 @@ param (
      [String] $Version
 )
 
-if ((Test-Path $FilePath -PathType Leaf) -ne $TRUE) {
+if ((Test-Path -Path $FilePath -PathType Leaf) -ne $TRUE) {
     Write-Error -Message ($FilePath + ' not found.') -Category InvalidArgument;
     exit 1;
 }
 
 #normalize path
-$FilePath = (Resolve-Path $FilePath).Path;
+$FilePath = (Resolve-Path -Path $FilePath).Path;
 
-$nuspecConfig = [xml] (Get-Content $FilePath);
+$nuspecConfig = [xml] (Get-Content -Path $FilePath);
 $nuspecConfig.DocumentElement.metadata.version = $Version;
 
 if (!$?) {


### PR DESCRIPTION
Modify PowerShell scripts to replace command aliases with full command names.

Also qualified parameters rather than relying on positional parameters.
