### PR TITLE
PowerShell script updates

### DIFF
--- a/CheckHelp.ps1
+++ b/CheckHelp.ps1
@@ -1,6 +1,10 @@
-
 Import-Module -Name PSReadline
 
+<<<<<<< HEAD
+Import-Module -Name PSReadline
+
+=======
+>>>>>>> Updates to PowerShell scripts for the following:
 $about_topic = Get-Help -Name about_PSReadline
 
 $methods = [PSConsoleUtilities.PSConsoleReadLine].GetMethods('public,static') |
@@ -61,4 +65,3 @@ Get-PSReadlineKeyHandler |
     ForEach-Object {
         "Function missing description: $($_.Function)"
     }
-

--- a/CheckHelp.ps1
+++ b/CheckHelp.ps1
@@ -1,7 +1,7 @@
 
-ipmo PSReadline
+Import-Module -Name PSReadline
 
-$about_topic = Get-Help about_PSReadline
+$about_topic = Get-Help -Name about_PSReadline
 
 $methods = [PSConsoleUtilities.PSConsoleReadLine].GetMethods('public,static') |
     Where-Object {
@@ -12,7 +12,7 @@ $methods = [PSConsoleUtilities.PSConsoleReadLine].GetMethods('public,static') |
             $parameters[1].ParameterType -eq [object]
     }
 
-foreach ($method in $methods)
+ForEach-Object ($method in $methods)
 {
     $parameters = $method.GetParameters()
     if ($parameters[0].Name -ne 'key' -or $parameters[1].Name -ne 'arg')
@@ -36,12 +36,12 @@ $methods.Name | ForEach-Object {
     }
 }
 
-$commonParameters = echo Debug Verbose OutVariable OutBuffer ErrorAction WarningAction ErrorVariable WarningVariable PipelineVariable
+$commonParameters = Write-Output Debug Verbose OutVariable OutBuffer ErrorAction WarningAction ErrorVariable WarningVariable PipelineVariable
 Get-Command -Type Cmdlet -Module PSReadline |
     ForEach-Object {
         $cmdletInfo = $_
         $cmdletName = $cmdletInfo.Name
-        $cmdletHelp = Get-Help -Detailed $cmdletName
+        $cmdletHelp = Get-Help -Name $cmdletName -Detailed
         $cmdletInfo.Parameters.Keys |
             ForEach-Object {
                 $parameterName = $_

--- a/MakeRelease.ps1
+++ b/MakeRelease.ps1
@@ -1,4 +1,3 @@
-
 param([switch]$Install)
 
 add-type -AssemblyName System.IO.Compression.FileSystem
@@ -17,8 +16,13 @@ if (Test-Path -Path $targetDir)
     Remove-Item -re $targetDir
 }
 
+<<<<<<< HEAD
 $null = New-Item -Path $targetDir -ItemType directory
 $null = New-Item -Path $targetDir\en-US -ItemType directory
+=======
+$null = mkdir -Path $targetDir
+$null = mkdir -Path $targetDir\en-US
+>>>>>>> Updates to PowerShell scripts for the following:
 
 $files = @('PSReadline\Changes.txt',
            'PSReadline\License.txt',
@@ -30,7 +34,11 @@ $files = @('PSReadline\Changes.txt',
 
 ForEach-Object ($file in $files)
 {
+<<<<<<< HEAD
     Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir
+=======
+    copy $PSScriptRoot\$file $targetDir
+>>>>>>> Updates to PowerShell scripts for the following:
 }
 
 $files = @('PSReadline\en-US\about_PSReadline.help.txt',
@@ -38,7 +46,11 @@ $files = @('PSReadline\en-US\about_PSReadline.help.txt',
 
 ForEach-Object ($file in $files)
 {
+<<<<<<< HEAD
     Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir\en-us
+=======
+    copy $PSScriptRoot\$file $targetDir\en-us
+>>>>>>> Updates to PowerShell scripts for the following:
 }
 
 $version = (Get-ChildItem -Path $targetDir\PSReadline.dll).VersionInfo.FileVersion
@@ -52,17 +64,29 @@ if (Get-Command -Name cpack -ea Ignore)
 
     if (Test-Path -Path $chocolateyDir\PSReadline)
     {
+<<<<<<< HEAD
         Remove-Item -Recurse -Path $chocolateyDir\PSReadline
+=======
+        rmdir -re $chocolateyDir\PSReadline
+>>>>>>> Updates to PowerShell scripts for the following:
     }
 
     & $PSScriptRoot\Update-NuspecVersion.ps1 "$chocolateyDir\PSReadline.nuspec" $version
 
+<<<<<<< HEAD
     Copy-Item -Recurse -Path $targetDir -Destination $chocolateyDir\PSReadline
+=======
+    copy -re $targetDir $chocolateyDir\PSReadline
+>>>>>>> Updates to PowerShell scripts for the following:
 
     cpack "$chocolateyDir\PSReadline.nuspec"
 }
 
+<<<<<<< HEAD
 Remove-Item -Path $PSScriptRoot\PSReadline.zip -ea Ignore
+=======
+rm $PSScriptRoot\PSReadline.zip -ea Ignore
+>>>>>>> Updates to PowerShell scripts for the following:
 [System.IO.Compression.ZipFile]::CreateFromDirectory($targetDir, "$PSScriptRoot\PSReadline.zip")
 
 if ($Install)
@@ -78,9 +102,15 @@ if ($Install)
     {
         if (Test-Path -Path $InstallDir\PSReadline)
         {
+<<<<<<< HEAD
             Remove-Item -Recurse -force -Path $InstallDir\PSReadline -ea Stop
         }
         Copy-Item -Recurse -Path $targetDir -Destination $InstallDir
+=======
+            rm -re -force -Path $InstallDir\PSReadline -ea Stop
+        }
+        copy -Recurse -Path $targetDir -Destination $InstallDir
+>>>>>>> Updates to PowerShell scripts for the following:
     }
     catch
     {

--- a/MakeRelease.ps1
+++ b/MakeRelease.ps1
@@ -3,7 +3,7 @@ param([switch]$Install)
 
 add-type -AssemblyName System.IO.Compression.FileSystem
 
-if (!(gcm msbuild -ea Ignore))
+if (!(Get-Command -Name msbuild -ea Ignore))
 {
     $env:path += ";${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319"
 }
@@ -12,13 +12,13 @@ msbuild $PSScriptRoot\PSReadline\PSReadLine.sln /t:Rebuild /p:Configuration=Rele
 
 $targetDir = "${env:Temp}\PSReadline"
 
-if (Test-Path $targetDir)
+if (Test-Path -Path $targetDir)
 {
-    rmdir -re $targetDir
+    Remove-Item -re $targetDir
 }
 
-$null = mkdir $targetDir
-$null = mkdir $targetDir\en-US
+$null = New-Item -Path $targetDir -ItemType directory
+$null = New-Item -Path $targetDir\en-US -ItemType directory
 
 $files = @('PSReadline\Changes.txt',
            'PSReadline\License.txt',
@@ -28,62 +28,62 @@ $files = @('PSReadline\Changes.txt',
            'PSReadline\PSReadline.format.ps1xml',
            'PSReadline\bin\Release\PSReadline.dll')
 
-foreach ($file in $files)
+ForEach-Object ($file in $files)
 {
-    cp $PSScriptRoot\$file $targetDir
+    Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir
 }
 
 $files = @('PSReadline\en-US\about_PSReadline.help.txt',
            'PSReadline\en-US\PSReadline.dll-help.xml')
 
-foreach ($file in $files)
+ForEach-Object ($file in $files)
 {
-    cp $PSScriptRoot\$file $targetDir\en-us
+    Copy-Item -Path $PSScriptRoot\$file -Destination $targetDir\en-us
 }
 
-$version = (Get-ChildItem $targetDir\PSReadline.dll).VersionInfo.FileVersion
+$version = (Get-ChildItem -Path $targetDir\PSReadline.dll).VersionInfo.FileVersion
 
 & $PSScriptRoot\Update-ModuleManifest.ps1 $targetDir\PSReadline.psd1 $version
 
 #make sure chocolatey is installed and in the path
-if (gcm cpack -ea Ignore)
+if (Get-Command -Name cpack -ea Ignore)
 {
     $chocolateyDir = "$PSScriptRoot\ChocolateyPackage"
 
-    if (Test-Path $chocolateyDir\PSReadline)
+    if (Test-Path -Path $chocolateyDir\PSReadline)
     {
-        rm -re $chocolateyDir\PSReadline
+        Remove-Item -Recurse -Path $chocolateyDir\PSReadline
     }
 
     & $PSScriptRoot\Update-NuspecVersion.ps1 "$chocolateyDir\PSReadline.nuspec" $version
 
-    cp -r $targetDir $chocolateyDir\PSReadline
+    Copy-Item -Recurse -Path $targetDir -Destination $chocolateyDir\PSReadline
 
     cpack "$chocolateyDir\PSReadline.nuspec"
 }
 
-del $PSScriptRoot\PSReadline.zip -ea Ignore
+Remove-Item -Path $PSScriptRoot\PSReadline.zip -ea Ignore
 [System.IO.Compression.ZipFile]::CreateFromDirectory($targetDir, "$PSScriptRoot\PSReadline.zip")
 
 if ($Install)
 {
     $InstallDir = "$HOME\Documents\WindowsPowerShell\Modules"
 
-    if (!(Test-Path $InstallDir))
+    if (!(Test-Path -Path $InstallDir))
     {
-        mkdir -force $InstallDir
+        New-Item -force -Path $InstallDir -ItemType Directory
     }
 
     try
     {
-        if (Test-Path $InstallDir\PSReadline)
+        if (Test-Path -Path $InstallDir\PSReadline)
         {
-            rm -Recurse -force $InstallDir\PSReadline -ea Stop
+            Remove-Item -Recurse -force -Path $InstallDir\PSReadline -ea Stop
         }
-        cp -Recurse $targetDir $InstallDir
+        Copy-Item -Recurse -Path $targetDir -Destination $InstallDir
     }
     catch
     {
-        Write-Error "Can't install, module is probably in use."
+        Write-Error -Message "Can't install, module is probably in use."
     }
 }

--- a/Update-ModuleManifest.ps1
+++ b/Update-ModuleManifest.ps1
@@ -5,15 +5,15 @@ param (
      [String] $Version
 )
 
-if ((Test-Path $FilePath -PathType Leaf) -ne $TRUE) {
+if ((Test-Path -Path $FilePath -PathType Leaf) -ne $TRUE) {
     Write-Error -Message ($FilePath + ' not found.') -Category InvalidArgument;
     exit 1;
 }
 
 #normalize path
-$FilePath = (Resolve-Path $FilePath).Path;
+$FilePath = (Resolve-Path -Path $FilePath).Path;
 
 $moduleVersionPattern = "ModuleVersion = '.*'";
 $newVersion = "ModuleVersion = '" + $Version + "'";
 
-(Get-Content $FilePath) | % {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content $FilePath;
+(Get-Content -Path $FilePath) | ForEach-Object {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content -Path $FilePath;

--- a/Update-NuspecVersion.ps1
+++ b/Update-NuspecVersion.ps1
@@ -5,15 +5,15 @@ param (
      [String] $Version
 )
 
-if ((Test-Path $FilePath -PathType Leaf) -ne $TRUE) {
+if ((Test-Path -Path $FilePath -PathType Leaf) -ne $TRUE) {
     Write-Error -Message ($FilePath + ' not found.') -Category InvalidArgument;
     exit 1;
 }
 
 #normalize path
-$FilePath = (Resolve-Path $FilePath).Path;
+$FilePath = (Resolve-Path -Path $FilePath).Path;
 
-$nuspecConfig = [xml] (Get-Content $FilePath);
+$nuspecConfig = [xml] (Get-Content -Path $FilePath);
 $nuspecConfig.DocumentElement.metadata.version = $Version;
 
 if (!$?) {


### PR DESCRIPTION
Updates to PowerShell scripts for the following:
Avoid use of positional parameters
Avoid usage of most aliases; left alone aliases based on "old" command line commands like mkdir, cd, rmdir.
