### PR TITLE
PowerShell script updates

### DIFF
--- a/CheckHelp.ps1
+++ b/CheckHelp.ps1
@@ -1,7 +1,6 @@
+Import-Module -Name PSReadline
 
-ipmo PSReadline
-
-$about_topic = Get-Help about_PSReadline
+$about_topic = Get-Help -Name about_PSReadline
 
 $methods = [PSConsoleUtilities.PSConsoleReadLine].GetMethods('public,static') |
     Where-Object {
@@ -36,7 +35,7 @@ $methods.Name | ForEach-Object {
     }
 }
 
-$commonParameters = echo Debug Verbose OutVariable OutBuffer ErrorAction WarningAction ErrorVariable WarningVariable PipelineVariable
+$commonParameters = Write-Output Debug Verbose OutVariable OutBuffer ErrorAction WarningAction ErrorVariable WarningVariable PipelineVariable
 Get-Command -Type Cmdlet -Module PSReadline |
     ForEach-Object {
         $cmdletInfo = $_
@@ -61,4 +60,3 @@ Get-PSReadlineKeyHandler |
     ForEach-Object {
         "Function missing description: $($_.Function)"
     }
-

--- a/MakeRelease.ps1
+++ b/MakeRelease.ps1
@@ -1,9 +1,8 @@
-
 param([switch]$Install)
 
 add-type -AssemblyName System.IO.Compression.FileSystem
 
-if (!(gcm msbuild -ea Ignore))
+if (-not(Get-Command -Name msbuild -ErrorAction Ignore))
 {
     $env:path += ";${env:SystemRoot}\Microsoft.Net\Framework\v4.0.30319"
 }
@@ -12,9 +11,9 @@ msbuild $PSScriptRoot\PSReadline\PSReadLine.sln /t:Rebuild /p:Configuration=Rele
 
 $targetDir = "${env:Temp}\PSReadline"
 
-if (Test-Path $targetDir)
+if (Test-Path -Path $targetDir)
 {
-    rmdir -re $targetDir
+    rmdir -Recurse $targetDir
 }
 
 $null = mkdir $targetDir
@@ -30,7 +29,7 @@ $files = @('PSReadline\Changes.txt',
 
 foreach ($file in $files)
 {
-    cp $PSScriptRoot\$file $targetDir
+    copy $PSScriptRoot\$file $targetDir
 }
 
 $files = @('PSReadline\en-US\about_PSReadline.help.txt',
@@ -38,52 +37,52 @@ $files = @('PSReadline\en-US\about_PSReadline.help.txt',
 
 foreach ($file in $files)
 {
-    cp $PSScriptRoot\$file $targetDir\en-us
+    copy $PSScriptRoot\$file $targetDir\en-us
 }
 
-$version = (Get-ChildItem $targetDir\PSReadline.dll).VersionInfo.FileVersion
+$version = (Get-ChildItem -Path $targetDir\PSReadline.dll).VersionInfo.FileVersion
 
 & $PSScriptRoot\Update-ModuleManifest.ps1 $targetDir\PSReadline.psd1 $version
 
 #make sure chocolatey is installed and in the path
-if (gcm cpack -ea Ignore)
+if (Get-Command -Name cpack -ErrorAction Ignore)
 {
     $chocolateyDir = "$PSScriptRoot\ChocolateyPackage"
 
-    if (Test-Path $chocolateyDir\PSReadline)
+    if (Test-Path -Path $chocolateyDir\PSReadline)
     {
-        rm -re $chocolateyDir\PSReadline
+        rmdir -Recurse $chocolateyDir\PSReadline
     }
 
     & $PSScriptRoot\Update-NuspecVersion.ps1 "$chocolateyDir\PSReadline.nuspec" $version
 
-    cp -r $targetDir $chocolateyDir\PSReadline
+    copy -Recurse $targetDir $chocolateyDir\PSReadline
 
     cpack "$chocolateyDir\PSReadline.nuspec"
 }
 
-del $PSScriptRoot\PSReadline.zip -ea Ignore
+del $PSScriptRoot\PSReadline.zip -ErrorAction Ignore
 [System.IO.Compression.ZipFile]::CreateFromDirectory($targetDir, "$PSScriptRoot\PSReadline.zip")
 
 if ($Install)
 {
     $InstallDir = "$HOME\Documents\WindowsPowerShell\Modules"
 
-    if (!(Test-Path $InstallDir))
+    if (-not(Test-Path -Path $InstallDir))
     {
         mkdir -force $InstallDir
     }
 
     try
     {
-        if (Test-Path $InstallDir\PSReadline)
+        if (Test-Path -Path $InstallDir\PSReadline)
         {
-            rm -Recurse -force $InstallDir\PSReadline -ea Stop
+            rmdir -Recurse -force $InstallDir\PSReadline -ErrorAction Stop
         }
-        cp -Recurse $targetDir $InstallDir
+        copy -Recurse $targetDir $InstallDir
     }
     catch
     {
-        Write-Error "Can't install, module is probably in use."
+        Write-Error -Message "Can't install, module is probably in use."
     }
 }

--- a/Update-ModuleManifest.ps1
+++ b/Update-ModuleManifest.ps1
@@ -5,15 +5,15 @@ param (
      [String] $Version
 )
 
-if ((Test-Path $FilePath -PathType Leaf) -ne $TRUE) {
+if ((Test-Path  -Path $FilePath -PathType Leaf) -ne $TRUE) {
     Write-Error -Message ($FilePath + ' not found.') -Category InvalidArgument;
     exit 1;
 }
 
 #normalize path
-$FilePath = (Resolve-Path $FilePath).Path;
+$FilePath = (Resolve-Path -Path $FilePath).Path;
 
 $moduleVersionPattern = "ModuleVersion = '.*'";
 $newVersion = "ModuleVersion = '" + $Version + "'";
 
-(Get-Content $FilePath) | % {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content $FilePath;
+(Get-Content -Path $FilePath) | ForEach-Object {$_ -replace $moduleVersionPattern, $newVersion} | Set-Content -Path $FilePath;

--- a/Update-NuspecVersion.ps1
+++ b/Update-NuspecVersion.ps1
@@ -5,15 +5,15 @@ param (
      [String] $Version
 )
 
-if ((Test-Path $FilePath -PathType Leaf) -ne $TRUE) {
+if ((Test-Path -Path $FilePath -PathType Leaf) -ne $TRUE) {
     Write-Error -Message ($FilePath + ' not found.') -Category InvalidArgument;
     exit 1;
 }
 
 #normalize path
-$FilePath = (Resolve-Path $FilePath).Path;
+$FilePath = (Resolve-Path -Path $FilePath).Path;
 
-$nuspecConfig = [xml] (Get-Content $FilePath);
+$nuspecConfig = [xml] (Get-Content -Path $FilePath);
 $nuspecConfig.DocumentElement.metadata.version = $Version;
 
 if (!$?) {


### PR DESCRIPTION
Qualified positional parameters
Removed most cmdlet aliases; left in place ones based on legacy command line utils (mkdir, rmdir, del)
Spelled out parameter names (ErrorAction instead of ea, Recurse instead of r or re)
