### PR TITLE
This should have been AltShiftD all along

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
                 // Added for xtermjs-based terminals that send different key combinations.
-                { Keys.AltShiftD,                   MakeKeyHandler(KillWord,                  "KillWord") },
+                { Keys.AltShiftD,              MakeKeyHandler(KillWord,                  "KillWord") },
                 { Keys.CtrlAt,                 MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.CtrlW,                  MakeKeyHandler(BackwardKillWord,          "BackwardKillWord")},
             };

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
                 // Added for xtermjs-based terminals that send different key combinations.
-                { Keys.AltD,                   MakeKeyHandler(KillWord,                  "KillWord") },
+                { Keys.AltShiftD,                   MakeKeyHandler(KillWord,                  "KillWord") },
                 { Keys.CtrlAt,                 MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.CtrlW,                  MakeKeyHandler(BackwardKillWord,          "BackwardKillWord")},
             };

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -532,6 +532,7 @@ namespace Microsoft.PowerShell
         public static PSKeyInfo AltY                = Alt('y');
         public static PSKeyInfo AltZ                = Alt('z');
         public static PSKeyInfo AltShiftB           = Alt('B');
+        public static PSKeyInfo AltShiftD           = Alt('D');
         public static PSKeyInfo AltShiftF           = Alt('F');
         public static PSKeyInfo AltSpace            = Alt(ConsoleKey.Spacebar);  // !Windows, system menu.
         public static PSKeyInfo AltPeriod           = Alt('.');  // !Linux, CLR bug


### PR DESCRIPTION
VS Code sends Alt+D when you hit Ctrl+Delete in VS Code and other xtermjs-based terminals.

I originally sent a PR to add AltD as a keybinding without realizing that this was `Alt+d` not `Alt+D`... this fixes that user error.

Proof:

In a vscode terminal pwsh
```pwsh
Set-PSReadLineKeyHandler -Chord Alt+D -Function KillWord
```

Then select a word and hit `Ctrl+Delete`