### PR TITLE
Revert "This should have been AltShiftD all along"

### DIFF
--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -230,7 +230,7 @@ namespace Microsoft.PowerShell
                 { Keys.F8,                     MakeKeyHandler(HistorySearchBackward,     "HistorySearchBackward") },
                 { Keys.ShiftF8,                MakeKeyHandler(HistorySearchForward,      "HistorySearchForward") },
                 // Added for xtermjs-based terminals that send different key combinations.
-                { Keys.AltShiftD,              MakeKeyHandler(KillWord,                  "KillWord") },
+                { Keys.AltD,                   MakeKeyHandler(KillWord,                  "KillWord") },
                 { Keys.CtrlAt,                 MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.CtrlW,                  MakeKeyHandler(BackwardKillWord,          "BackwardKillWord")},
             };

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -532,7 +532,6 @@ namespace Microsoft.PowerShell
         public static PSKeyInfo AltY                = Alt('y');
         public static PSKeyInfo AltZ                = Alt('z');
         public static PSKeyInfo AltShiftB           = Alt('B');
-        public static PSKeyInfo AltShiftD           = Alt('D');
         public static PSKeyInfo AltShiftF           = Alt('F');
         public static PSKeyInfo AltSpace            = Alt(ConsoleKey.Spacebar);  // !Windows, system menu.
         public static PSKeyInfo AltPeriod           = Alt('.');  // !Linux, CLR bug


### PR DESCRIPTION
Reverts PowerShell/PSReadLine#1037

VS Code will be fixing this - https://github.com/microsoft/vscode/pull/80824

cc @daxian-dbw @tyriar