### PR TITLE
Add an key binding example: 'ForwardCharAndAcceptNextSuggestionWord'

### DIFF
--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -562,6 +562,7 @@ Set-PSReadLineKeyHandler -Key Alt+j `
     [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
 }
 
+# Auto correct 'git cmt' to 'git commit'
 Set-PSReadLineOption -CommandValidationHandler {
     param([CommandAst]$CommandAst)
 
@@ -577,5 +578,26 @@ Set-PSReadLineOption -CommandValidationHandler {
                 }
             }
         }
+    }
+}
+
+# It is built-in to 'ForwardChar' to accept the whole suggestion text when the cursor is
+# already at the end of the current editing line.
+# This is a custom binding to make 'RightArrow' behave like 'ForwardChar' but accept the
+# next word of the suggestion text when the cursor is at the end of the editing line.
+Set-PSReadLineKeyHandler -Key RightArrow `
+                         -BriefDescription ForwardCharAndAcceptNextSuggestionWord `
+                         -LongDescription "Move cursor one character to the right in the current editing line and accept the next word in suggestion when it's at the end of current editing line" `
+                         -ScriptBlock {
+    param($key, $arg)
+
+    $line = $null
+    $cursor = $null
+    [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$line, [ref]$cursor)
+
+    if ($cursor -lt $line.Length) {
+        [Microsoft.PowerShell.PSConsoleReadLine]::ForwardChar($key, $arg)
+    } else {
+        [Microsoft.PowerShell.PSConsoleReadLine]::AcceptNextSuggestionWord($key, $arg)
     }
 }

--- a/PSReadLine/SamplePSReadLineProfile.ps1
+++ b/PSReadLine/SamplePSReadLineProfile.ps1
@@ -581,10 +581,8 @@ Set-PSReadLineOption -CommandValidationHandler {
     }
 }
 
-# It is built-in to 'ForwardChar' to accept the whole suggestion text when the cursor is
-# already at the end of the current editing line.
-# This is a custom binding to make 'RightArrow' behave like 'ForwardChar' but accept the
-# next word of the suggestion text when the cursor is at the end of the editing line.
+# `ForwardChar` accepts the entire suggestion text when the cursor is at the end of the line.
+# This custom binding makes `RightArrow` behave similarly - accepting the next word instead of the entire suggestion text.
 Set-PSReadLineKeyHandler -Key RightArrow `
                          -BriefDescription ForwardCharAndAcceptNextSuggestionWord `
                          -LongDescription "Move cursor one character to the right in the current editing line and accept the next word in suggestion when it's at the end of current editing line" `


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

It is built-in to `ForwardChar` to accept the whole suggestion text when the cursor is already at the end of the current editing line.
This PR adds a custom binding example to make `RightArrow` behave like `ForwardChar` but accept the next word of the suggestion text when the cursor is at the end of the editing line.

Related issue: #1596

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/PowerShell/PSReadLine/pull/1601)