### PR TITLE
Generate ADO SBOM for PSReadLine

### DIFF
--- a/.vsts-ci/releaseBuild.yml
+++ b/.vsts-ci/releaseBuild.yml
@@ -6,6 +6,7 @@ variables:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  SBOMGenerator_Formats: 'spdx:2.2'
 
 resources:
   repositories:
@@ -105,6 +106,13 @@ stages:
             throw "Certificate should have the subject starts with 'Microsoft Corporation'"
         }
       displayName: 'Verify the signed files'
+
+    # Generate a Software Bill of Materials (SBOM)
+    - template: Sbom.yml@ComplianceRepo
+      parameters:
+        BuildDropPath: '$(PSReadLine)'
+        Build_Repository_Uri: 'https://github.com/PowerShell/PSReadLine.git'
+        displayName: Generate SBOM
 
     - pwsh: |
         try {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Generate a Software Bill of Materials (SBOM), which is a legal requirement.

Verified by the build: https://dev.azure.com/mscodehub/PSReadLine/_build/results?buildId=216553&view=results
The SBOM was successfully generated.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2918)