### PR TITLE
Generate `OnIdle` event only if the editing buffer is empty

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -218,18 +218,27 @@ namespace Microsoft.PowerShell
                         bool runPipelineForEventProcessing = false;
                         foreach (var sub in eventSubscribers)
                         {
-                            runPipelineForEventProcessing = true;
                             if (sub.SourceIdentifier.Equals(PSEngineEvent.OnIdle, StringComparison.OrdinalIgnoreCase))
                             {
-                                // There is an OnIdle event.  We're idle because we timed out.  Normally
+                                // If the buffer is not empty, let's not consider we are idle because the user
+                                // is in the middle of typing something.
+                                if (_singleton._buffer.Length > 0)
+                                {
+                                    continue;
+                                }
+
+                                // There is an OnIdle event. We timed out and the buffer is empty.  Normally
                                 // PowerShell generates this event, but PowerShell assumes the engine is not
                                 // idle because it called PSConsoleHostReadLine which isn't returning.
                                 // So we generate the event instead.
+                                runPipelineForEventProcessing = true;
                                 _singleton._engineIntrinsics.Events.GenerateEvent(PSEngineEvent.OnIdle, null, null, null);
 
                                 // Break out so we don't genreate more than one 'OnIdle' event for a timeout.
                                 break;
                             }
+
+                            runPipelineForEventProcessing = true;
                         }
 
                         // If there are any event subscribers, run a tiny useless PowerShell pipeline

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -220,17 +220,15 @@ namespace Microsoft.PowerShell
                         {
                             if (sub.SourceIdentifier.Equals(PSEngineEvent.OnIdle, StringComparison.OrdinalIgnoreCase))
                             {
-                                // If the buffer is not empty, let's not consider we are idle because the user
-                                // is in the middle of typing something.
+                                // If the buffer is not empty, let's not consider we are idle because the user is in the middle of typing something.
                                 if (_singleton._buffer.Length > 0)
                                 {
                                     continue;
                                 }
 
-                                // There is an OnIdle event. We timed out and the buffer is empty.  Normally
-                                // PowerShell generates this event, but PowerShell assumes the engine is not
-                                // idle because it called PSConsoleHostReadLine which isn't returning.
-                                // So we generate the event instead.
+                                // There is an OnIdle event subscriber and we are idle because we timed out and the buffer is empty.
+                                // Normally PowerShell generates this event, but PowerShell assumes the engine is not idle because
+                                // it called PSConsoleHostReadLine which isn't returning. So we generate the event instead.
                                 runPipelineForEventProcessing = true;
                                 _singleton._engineIntrinsics.Events.GenerateEvent(PSEngineEvent.OnIdle, null, null, null);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Generate `OnIdle` event only if the editing buffer is empty. But if there is any other event subscribers, we still run the dummy pipeline to allow potential event handling.

`OnIdle` event by definition is not an event that need urgent processing, and sometimes it's used by module/script to output a message, e.g. `Az.Predictor` uses it to write out a ask-for-survey message. Having this event to fire when the user already input something in the buffer is not a good experience for the user. See the following screenshot as an example.

![image](https://user-images.githubusercontent.com/127450/139136817-52498887-e27b-46ae-95ad-012c4b563030.png)

With this PR, we generate the `OnIdle` event only if the editing buffer is empty. But for any other event subscribers, we still run the dummy pipeline to allow potential event processing for them even if the editing buffer is not empty.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/8270


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/2934)