### PR TITLE
Enable IntelliSense prediction by default

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -165,7 +165,7 @@ namespace Microsoft.PowerShell
         /// </summary>
         public const int DefaultAnsiEscapeTimeout = 100;
 
-        public PSConsoleReadLineOptions(string hostName)
+        public PSConsoleReadLineOptions(string hostName, bool usingLegacyConsole)
         {
             ResetColors();
             EditMode = DefaultEditMode;
@@ -185,7 +185,11 @@ namespace Microsoft.PowerShell
             HistorySearchCaseSensitive = DefaultHistorySearchCaseSensitive;
             HistorySaveStyle = DefaultHistorySaveStyle;
             AnsiEscapeTimeout = DefaultAnsiEscapeTimeout;
-            PredictionSource = DefaultPredictionSource;
+            PredictionSource = usingLegacyConsole
+                ? PredictionSource.None
+                : Environment.Version.Major < 6
+                    ? PredictionSource.History
+                    : PredictionSource.HistoryAndPlugin;
             PredictionViewStyle = DefaultPredictionViewStyle;
             MaximumHistoryCount = 0;
 

--- a/PSReadLine/KeyBindings.cs
+++ b/PSReadLine/KeyBindings.cs
@@ -230,6 +230,8 @@ namespace Microsoft.PowerShell
                 { Keys.AltMinus,               MakeKeyHandler(DigitArgument,             "DigitArgument") },
                 { Keys.AltQuestion,            MakeKeyHandler(WhatIsKey,                 "WhatIsKey") },
                 { Keys.AltA,                   MakeKeyHandler(SelectCommandArgument,     "SelectCommandArgument") },
+                { Keys.AltH,                   MakeKeyHandler(ShowParameterHelp,         "ShowParameterHelp") },
+                { Keys.F1,                     MakeKeyHandler(ShowCommandHelp,           "ShowCommandHelp") },
                 { Keys.F2,                     MakeKeyHandler(SwitchPredictionView,      "SwitchPredictionView") },
                 { Keys.F3,                     MakeKeyHandler(CharacterSearch,           "CharacterSearch") },
                 { Keys.ShiftF3,                MakeKeyHandler(CharacterSearchBackward,   "CharacterSearchBackward") },
@@ -239,8 +241,6 @@ namespace Microsoft.PowerShell
                 { Keys.AltD,                   MakeKeyHandler(KillWord,                  "KillWord") },
                 { Keys.CtrlAt,                 MakeKeyHandler(MenuComplete,              "MenuComplete") },
                 { Keys.CtrlW,                  MakeKeyHandler(BackwardKillWord,          "BackwardKillWord") },
-                { Keys.AltH,                   MakeKeyHandler(ShowParameterHelp,         "ShowParameterHelp") },
-                { Keys.F1,                     MakeKeyHandler(ShowCommandHelp,           "ShowCommandHelp") },
             };
 
             // Some bindings are not available on certain platforms
@@ -338,6 +338,7 @@ namespace Microsoft.PowerShell
                 { Keys.AltA,                   MakeKeyHandler(SelectCommandArgument,     "SelectCommandArgument") },
                 { Keys.AltH,                   MakeKeyHandler(ShowParameterHelp,         "ShowParameterHelp") },
                 { Keys.F1,                     MakeKeyHandler(ShowCommandHelp,           "ShowCommandHelp") },
+                { Keys.F2,                     MakeKeyHandler(SwitchPredictionView,      "SwitchPredictionView") },
             };
 
             // Some bindings are not available on certain platforms

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -686,7 +686,9 @@ namespace Microsoft.PowerShell
             {
                 hostName = PSReadLine;
             }
-            _options = new PSConsoleReadLineOptions(hostName);
+
+            bool usingLegacyConsole = _console is PlatformWindows.LegacyWin32Console;
+            _options = new PSConsoleReadLineOptions(hostName, usingLegacyConsole);
             _prediction = new Prediction(this);
             SetDefaultBindings(_options.EditMode);
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Enable intellisense prediction by default:
- when VT is not supported, `PredictionSource` is set to `None` by default
- when VT is supported and it's running with PowerShell 7.2+, `PredictionSource` is set to `HistoryAndPlugin` by default
- when VT is supported and it's running with PowerShell prior to 7.2, `PredictionSource` is set to `History` by default

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/8943


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/PowerShell/PSReadLine/pull/3351)