### PR TITLE
Add Y bounds check to InvokePrompt (Fixes #4790)

### DIFF
--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -1035,16 +1035,24 @@ namespace Microsoft.PowerShell
         public static void InvokePrompt(ConsoleKeyInfo? key = null, object arg = null)
         {
             var console = _singleton._console;
-            console.CursorVisible = false;
 
             if (arg is int newY)
             {
+                if (newY < 0 || newY >= console.BufferHeight)
+                    throw new ArgumentOutOfRangeException(nameof(arg));
+                    
+                console.CursorVisible = false;
                 console.SetCursorPosition(0, newY);
             }
             else
             {
                 newY = _singleton._initialY - _singleton._options.ExtraPromptLineCount;
 
+                // Silently return if user has implicitly requested an impossible prompt invocation.
+                if (newY < 0)
+                    return;
+
+                console.CursorVisible = false;
                 console.SetCursorPosition(0, newY);
 
                 // We need to rewrite the prompt, so blank out everything from a previous prompt invocation

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -1039,8 +1039,10 @@ namespace Microsoft.PowerShell
             if (arg is int newY)
             {
                 if (newY < 0 || newY >= console.BufferHeight)
+                {
                     throw new ArgumentOutOfRangeException(nameof(arg));
-                    
+                }
+
                 console.CursorVisible = false;
                 console.SetCursorPosition(0, newY);
             }
@@ -1050,7 +1052,9 @@ namespace Microsoft.PowerShell
 
                 // Silently return if user has implicitly requested an impossible prompt invocation.
                 if (newY < 0)
+                {
                     return;
+                }
 
                 console.CursorVisible = false;
                 console.SetCursorPosition(0, newY);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fixes #4790

Aligns behavior with that stated in issue #4790:

- Add a bounds check to make calls to InvokePrompt silently return if it's not possible to redraw the entire prompt and no Y position was specified by the caller.
- Check and directly throw an exception if a call is made to InvokePrompt with an explicit Y position that is not possible.

Since implicit callers (i.e. those not specifying a Y position) can't know where the prompt will get written, they can't guard against accidentally trying to update a prompt that's left the buffer. The only thing that can be done by anyone once the prompt has left the screen is to accept the line or abort.

Explicit callers passing a Y value in 'arg' at least know where they are trying to write the prompt so we can throw the exception and let them handle/recover (if desired).

<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [X] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [X] Summarized changes
- [ ] Make sure you've added one or more new tests
- [X] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [X] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [X] Doc Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/12157

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4791)