### PR TITLE
Add Sqlite option for PSReadline

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "-NoProfile",
                 "-NoExit",
                 "-Command",
-                "Import-Module '${workspaceFolder}/PSReadLine/bin/Debug/net8.0/PSReadLine.psd1'"
+                \"Import-Module '${workspaceFolder}/PSReadLine/bin/Debug/net8.0/PSReadLine.psd1'\"
             ],
             "console": "integratedTerminal",
             "justMyCode": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
                 "-NoProfile",
                 "-NoExit",
                 "-Command",
-                \"Import-Module '${workspaceFolder}/PSReadLine/bin/Debug/net8.0/PSReadLine.psd1'\"
+                "Import-Module '${workspaceFolder}/PSReadLine/bin/Debug/net8.0/PSReadLine.psd1'"
             ],
             "console": "integratedTerminal",
             "justMyCode": false,

--- a/PSReadLine.build.ps1
+++ b/PSReadLine.build.ps1
@@ -57,6 +57,23 @@ Synopsis: Build main binary module
 #>
 task BuildMainModule @binaryModuleParams {
     exec { dotnet publish -c $Configuration PSReadLine\PSReadLine.csproj }
+
+    # Restructure native SQLite DLLs from NuGet runtimes/{rid}/native/ into flat {rid}/ layout
+    # that PowerShell's CorePsAssemblyLoadContext.NativeDllHandler expects.
+    $publishPath = "PSReadLine/bin/$Configuration/$targetFramework/publish"
+    $runtimesDir = Join-Path $publishPath 'runtimes'
+    if (Test-Path $runtimesDir) {
+        Get-ChildItem $runtimesDir -Directory | ForEach-Object {
+            $rid = $_.Name
+            $nativeDir = Join-Path $_.FullName 'native'
+            if (Test-Path $nativeDir) {
+                $dest = Join-Path $publishPath $rid
+                New-Item -Path $dest -ItemType Directory -Force > $null
+                Copy-Item (Join-Path $nativeDir '*') $dest -Force
+            }
+        }
+        Remove-Item $runtimesDir -Recurse -Force
+    }
 }
 
 <#
@@ -109,6 +126,31 @@ task LayoutModule BuildMainModule, {
     $binPath = "PSReadLine/bin/$Configuration/$targetFramework/publish"
     Copy-Item $binPath/Microsoft.PowerShell.PSReadLine.dll $targetDir
     Copy-Item $binPath/Microsoft.PowerShell.Pager.dll $targetDir
+
+    # Copy SQLite managed DLLs
+    foreach ($dll in @(
+        'Microsoft.Data.Sqlite.dll',
+        'SQLitePCLRaw.core.dll',
+        'SQLitePCLRaw.batteries_v2.dll',
+        'SQLitePCLRaw.provider.e_sqlite3.dll'
+    )) {
+        $dllPath = Join-Path $binPath $dll
+        if (Test-Path $dllPath) {
+            Copy-Item $dllPath $targetDir
+        }
+    }
+
+    # Copy native SQLite DLLs in flat {rid}/ layout for PowerShell's NativeDllHandler
+    foreach ($rid in @('win-x64','win-x86','win-arm','win-arm64','linux-x64','linux-x86','linux-arm','linux-arm64','linux-musl-x64','linux-musl-arm64','osx-x64','osx-arm64')) {
+        $ridSource = Join-Path $binPath $rid
+        if (Test-Path $ridSource) {
+            $ridDest = Join-Path $targetDir $rid
+            if (-not (Test-Path $ridDest)) {
+                New-Item $ridDest -ItemType Directory -Force > $null
+            }
+            Copy-Item "$ridSource/*" $ridDest -Force
+        }
+    }
 
     if ($Configuration -eq 'Debug') {
         Copy-Item $binPath/*.pdb $targetDir

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -115,8 +115,8 @@ namespace Microsoft.PowerShell
         public const string DefaultContinuationPrompt = ">> ";
 
         /// <summary>
-        /// The default history format is text.  The SQLite is experimental.
-        /// It is not recommended to use it for production yet.
+        /// The default history type is text-based history.
+        /// Users can change default behavior by setting this to SQLite in their profile.
         /// </summary>
         public const HistoryType DefaultHistoryType = HistoryType.Text;
 

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -62,7 +62,14 @@ namespace Microsoft.PowerShell
     {
         SkipAdding,
         MemoryOnly,
-        MemoryAndFile
+        MemoryAndFile,
+        SQLite
+    }
+
+    public enum HistoryType
+    {
+        Text,
+        SQLite
     }
 
     public enum PredictionSource
@@ -106,6 +113,12 @@ namespace Microsoft.PowerShell
         public static readonly EditMode DefaultEditMode;
 
         public const string DefaultContinuationPrompt = ">> ";
+
+        /// <summary>
+        /// The default history format is text.  The SQLite is experimental.
+        /// It is not recommended to use it for production yet.
+        /// </summary>
+        public const HistoryType DefaultHistoryType = HistoryType.Text;
 
         /// <summary>
         /// The maximum number of commands to store in the history.
@@ -198,6 +211,7 @@ namespace Microsoft.PowerShell
             ResetColors();
             EditMode = DefaultEditMode;
             ScreenReaderModeEnabled = Accessibility.IsScreenReaderActive();
+            HistoryType = DefaultHistoryType;
             ContinuationPrompt = DefaultContinuationPrompt;
             ContinuationPromptColor = Console.ForegroundColor;
             ExtraPromptLineCount = DefaultExtraPromptLineCount;
@@ -232,6 +246,13 @@ namespace Microsoft.PowerShell
                     "PowerShell",
                     "PSReadLine",
                     historyFileName);
+                SqliteHistorySavePath = System.IO.Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "Microsoft",
+                    "Windows",
+                    "PowerShell",
+                    "PSReadLine",
+                    hostName + "_history.db");
             }
             else
             {
@@ -333,6 +354,7 @@ namespace Microsoft.PowerShell
         /// that do invoke the script block - this covers the most useful cases.
         /// </summary>
         public HashSet<string> CommandsToValidateScriptBlockArguments { get; set; }
+        public HistoryType HistoryType { get; set; } = HistoryType.Text;
 
         /// <summary>
         /// When true, duplicates will not be recalled from history more than once.
@@ -372,6 +394,11 @@ namespace Microsoft.PowerShell
         /// The path to the saved history.
         /// </summary>
         public string HistorySavePath { get; set; }
+
+        /// <summary>
+        /// The path to the SQLite history database.
+        /// </summary>
+        public string SqliteHistorySavePath { get; set; }
         public HistorySaveStyle HistorySaveStyle { get; set; }
 
         /// <summary>
@@ -654,6 +681,20 @@ namespace Microsoft.PowerShell
         [Parameter]
         [AllowEmptyString]
         public string ContinuationPrompt { get; set; }
+
+        [Parameter]
+        public HistoryType HistoryType
+        {
+            get => _historyType.GetValueOrDefault();
+            set
+            {
+                _historyType = value;
+                _historyTypeSpecified = true;
+            }
+        }
+
+        public HistoryType? _historyType = HistoryType.Text;
+        internal bool _historyTypeSpecified;
 
         [Parameter]
         public SwitchParameter HistoryNoDuplicates

--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -239,14 +239,14 @@ namespace Microsoft.PowerShell
             var historyFileName = hostName + "_history.txt";
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                HistorySavePath = System.IO.Path.Combine(
+                HistorySavePathText = System.IO.Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                     "Microsoft",
                     "Windows",
                     "PowerShell",
                     "PSReadLine",
                     historyFileName);
-                SqliteHistorySavePath = System.IO.Path.Combine(
+                HistorySavePathSQLite = System.IO.Path.Combine(
                     Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
                     "Microsoft",
                     "Windows",
@@ -261,11 +261,16 @@ namespace Microsoft.PowerShell
 
                 if (!String.IsNullOrEmpty(historyPath))
                 {
-                    HistorySavePath = System.IO.Path.Combine(
+                    HistorySavePathText = System.IO.Path.Combine(
                         historyPath,
                         "powershell",
                         "PSReadLine",
                         historyFileName);
+                    HistorySavePathSQLite = System.IO.Path.Combine(
+                        historyPath,
+                        "powershell",
+                        "PSReadLine",
+                        hostName + "_history.db");
                 }
                 else
                 {
@@ -274,18 +279,26 @@ namespace Microsoft.PowerShell
 
                     if (!String.IsNullOrEmpty(home))
                     {
-                        HistorySavePath = System.IO.Path.Combine(
+                        HistorySavePathText = System.IO.Path.Combine(
                             home,
                             ".local",
                             "share",
                             "powershell",
                             "PSReadLine",
                             historyFileName);
+                        HistorySavePathSQLite = System.IO.Path.Combine(
+                            home,
+                            ".local",
+                            "share",
+                            "powershell",
+                            "PSReadLine",
+                            hostName + "_history.db");
                     }
                     else
                     {
                         // No HOME, then don't save anything
-                        HistorySavePath = "/dev/null";
+                        HistorySavePathText = "/dev/null";
+                        HistorySavePathSQLite = "/dev/null";
                     }
                 }
             }
@@ -391,14 +404,23 @@ namespace Microsoft.PowerShell
         public ScriptBlock ViModeChangeHandler { get; set; }
 
         /// <summary>
-        /// The path to the saved history.
+        /// The path to the text history file.
         /// </summary>
-        public string HistorySavePath { get; set; }
+        public string HistorySavePathText { get; set; }
 
         /// <summary>
         /// The path to the SQLite history database.
         /// </summary>
-        public string SqliteHistorySavePath { get; set; }
+        public string HistorySavePathSQLite { get; set; }
+
+        /// <summary>
+        /// Returns the active history save path based on the current <see cref="HistoryType"/>.
+        /// </summary>
+        public string HistorySavePath => HistoryType switch
+        {
+            HistoryType.SQLite => HistorySavePathSQLite,
+            _ => HistorySavePathText,
+        };
         public HistorySaveStyle HistorySaveStyle { get; set; }
 
         /// <summary>
@@ -826,15 +848,27 @@ namespace Microsoft.PowerShell
 
         [Parameter]
         [ValidateNotNullOrEmpty]
-        public string HistorySavePath
+        public string HistorySavePathText
         {
-            get => _historySavePath;
+            get => _historySavePathText;
             set
             {
-                _historySavePath = GetUnresolvedProviderPathFromPSPath(value);
+                _historySavePathText = GetUnresolvedProviderPathFromPSPath(value);
             }
         }
-        private string _historySavePath;
+        private string _historySavePathText;
+
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        public string HistorySavePathSQLite
+        {
+            get => _historySavePathSQLite;
+            set
+            {
+                _historySavePathSQLite = GetUnresolvedProviderPathFromPSPath(value);
+            }
+        }
+        private string _historySavePathSQLite;
 
         [Parameter]
         [ValidateRange(25, 1000)]

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -164,7 +164,6 @@ namespace Microsoft.PowerShell
 
             if (Options.HistoryType is HistoryType.SQLite)
             {
-                InitializeSQLiteDatabase();
                 return AddToHistoryOption.SQLite; 
             }
 
@@ -212,7 +211,6 @@ namespace Microsoft.PowerShell
 
         private void InitializeSQLiteDatabase()
         {
-            // Path to the SQLite database file
             string baseConnectionString = $"Data Source={_options.HistorySavePath}";
             var connectionString = new SqliteConnectionStringBuilder(baseConnectionString)
             {
@@ -224,47 +222,188 @@ namespace Microsoft.PowerShell
                 using var connection = new SqliteConnection(connectionString);
                 connection.Open();
 
-                // Check if the "History" table exists
+                // Check if the "Commands" table exists (our primary table for new schema)
                 using var command = connection.CreateCommand();
                 command.CommandText = @"
-                            SELECT name
-                            FROM sqlite_master
-                            WHERE type='table' AND name=@TableName";
-                command.Parameters.AddWithValue("@TableName", "History");
+SELECT name
+FROM sqlite_master
+WHERE type='table' AND name=@TableName";
+                command.Parameters.AddWithValue("@TableName", "Commands");
 
                 var result = command.ExecuteScalar();
+                bool isNewDatabase = result == null;
 
-                // If the table doesn't exist, create it
-                if (result == null)
+                // If the table doesn't exist, create the normalized schema
+                if (isNewDatabase)
                 {
-                    using var createTableCommand = connection.CreateCommand();
-                    createTableCommand.CommandText = @"
-                                    CREATE TABLE IF NOT EXISTS History (
-                                        Id INTEGER PRIMARY KEY AUTOINCREMENT,
-                                        CommandLine TEXT NOT NULL,
-                                        StartTime DATETIME NOT NULL,
-                                        ElapsedTime INTEGER NOT NULL,
-                                        Location TEXT NOT NULL
-                                    )";
-                    createTableCommand.ExecuteNonQuery();
+                    using var createTablesCommand = connection.CreateCommand();
+                    createTablesCommand.CommandText = @"
+-- Table for storing unique command lines
+CREATE TABLE Commands (
+    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    CommandLine TEXT NOT NULL UNIQUE,
+    CommandHash TEXT NOT NULL UNIQUE
+);
+
+-- Table for storing unique locations
+CREATE TABLE Locations (
+    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    Path TEXT NOT NULL UNIQUE
+);
+
+-- Table for storing execution history with foreign keys
+CREATE TABLE ExecutionHistory (
+    Id INTEGER PRIMARY KEY AUTOINCREMENT,
+    CommandId INTEGER NOT NULL,
+    LocationId INTEGER NOT NULL,
+    StartTime INTEGER NOT NULL,
+    ElapsedTime INTEGER NOT NULL,
+    ExecutionCount INTEGER DEFAULT 1,
+    LastExecuted INTEGER NOT NULL,
+    FOREIGN KEY (CommandId) REFERENCES Commands(Id),
+    FOREIGN KEY (LocationId) REFERENCES Locations(Id),
+    UNIQUE(CommandId, LocationId)
+);
+
+-- Create indexes for optimal performance
+CREATE INDEX idx_commands_hash ON Commands(CommandHash);
+CREATE INDEX idx_locations_path ON Locations(Path);
+CREATE INDEX idx_execution_last_executed ON ExecutionHistory(LastExecuted DESC);
+CREATE INDEX idx_execution_count ON ExecutionHistory(ExecutionCount DESC);
+CREATE INDEX idx_execution_location_time ON ExecutionHistory(LocationId, LastExecuted DESC);
+
+-- Create a view for easy querying (mimics the old single-table structure)
+CREATE VIEW HistoryView AS
+SELECT 
+    eh.Id,
+    c.CommandLine,
+    c.CommandHash,
+    l.Path as Location,
+    eh.StartTime,
+    eh.ElapsedTime,
+    eh.ExecutionCount,
+    eh.LastExecuted
+FROM ExecutionHistory eh
+JOIN Commands c ON eh.CommandId = c.Id
+JOIN Locations l ON eh.LocationId = l.Id;";
+                    createTablesCommand.ExecuteNonQuery();
+
+                    // Migrate existing text file history if it exists
+                    // MigrateTextHistoryToSQLite(connection);
                 }
             }
             catch (SqliteException ex)
             {
-                // Handle SQLite-specific exceptions
                 Console.WriteLine($"SQLite error initializing database: {ex.Message}");
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"Error initializing SQLite database: {ex.Message}");
+            }
+        }
 
-                Console.WriteLine($"Stack Trace: {ex.StackTrace}");
-
-                if (ex.InnerException != null)
+        private void MigrateTextHistoryToSQLite(SqliteConnection connection)
+        {
+            // Check if text history file exists
+            string textHistoryPath = _options.HistorySavePath.Replace(".sqlite", ".txt");
+            if (!File.Exists(textHistoryPath))
+            {
+                // Try default history path pattern
+                textHistoryPath = Path.ChangeExtension(_options.HistorySavePath, ".txt");
+                if (!File.Exists(textHistoryPath))
                 {
-                    Console.WriteLine($"Inner Exception: {ex.InnerException.Message}");
-                    Console.WriteLine($"Inner Exception Stack Trace: {ex.InnerException.StackTrace}");
+                    return; // No text history to migrate
                 }
+            }
+
+            try
+            {
+                // Read existing text history using the existing connection (don't open a new one)
+                var historyLines = ReadHistoryLinesImpl(textHistoryPath, int.MaxValue);
+                var historyItems = new List<HistoryItem>();
+
+                // Convert text lines to HistoryItems
+                var sb = new StringBuilder();
+                foreach (var line in historyLines)
+                {
+                    if (line.EndsWith("`", StringComparison.Ordinal))
+                    {
+                        sb.Append(line, 0, line.Length - 1);
+                        sb.Append('\n');
+                    }
+                    else if (sb.Length > 0)
+                    {
+                        sb.Append(line);
+                        historyItems.Add(new HistoryItem
+                        {
+                            CommandLine = sb.ToString(),
+                            StartTime = DateTime.UtcNow.AddMinutes(-historyItems.Count), // Approximate timestamps
+                            ApproximateElapsedTime = TimeSpan.Zero,
+                            Location = "Unknown"
+                        });
+                        sb.Clear();
+                    }
+                    else
+                    {
+                        historyItems.Add(new HistoryItem
+                        {
+                            CommandLine = line,
+                            StartTime = DateTime.UtcNow.AddMinutes(-historyItems.Count), // Approximate timestamps
+                            ApproximateElapsedTime = TimeSpan.Zero,
+                            Location = "Unknown"
+                        });
+                    }
+                }
+
+                // Insert into SQLite database using the new normalized schema
+                using var transaction = connection.BeginTransaction();
+
+                foreach (var item in historyItems)
+                {
+                    try
+                    {
+                        // Generate command hash using SHA256
+                        string commandHash = ComputeCommandHash(item.CommandLine);
+                        string location = item.Location ?? "Unknown";
+
+                        // Get or create command and location IDs
+                        long commandId = GetOrCreateCommandId(connection, item.CommandLine, commandHash);
+                        long locationId = GetOrCreateLocationId(connection, location);
+
+                        // Convert DateTime to Unix timestamp (INTEGER)
+                        long startTimeUnix = ((DateTimeOffset)item.StartTime).ToUnixTimeSeconds();
+                        long lastExecutedUnix = startTimeUnix;
+
+                        // Insert or update execution history using the new schema
+                        using var command = connection.CreateCommand();
+                        command.Transaction = transaction;
+                        command.CommandText = @"
+INSERT INTO ExecutionHistory (CommandId, LocationId, StartTime, ElapsedTime, ExecutionCount, LastExecuted)
+VALUES (@CommandId, @LocationId, @StartTime, @ElapsedTime, 1, @LastExecuted)
+ON CONFLICT(CommandId, LocationId) DO UPDATE SET
+    ExecutionCount = ExecutionCount + 1,
+    LastExecuted = excluded.LastExecuted";
+
+                        command.Parameters.AddWithValue("@CommandId", commandId);
+                        command.Parameters.AddWithValue("@LocationId", locationId);
+                        command.Parameters.AddWithValue("@StartTime", startTimeUnix);
+                        command.Parameters.AddWithValue("@ElapsedTime", item.ApproximateElapsedTime.Ticks);
+                        command.Parameters.AddWithValue("@LastExecuted", lastExecutedUnix);
+                        command.ExecuteNonQuery();
+                    }
+                    catch (Exception itemEx)
+                    {
+                        Console.WriteLine($"Error migrating history item: {itemEx.Message}");
+                        // Continue with next item
+                    }
+                }
+
+                transaction.Commit();
+                Console.WriteLine($"Migrated {historyItems.Count} history items from text file to SQLite");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error migrating text history: {ex.Message}");
             }
         }
 
@@ -361,12 +500,60 @@ namespace Microsoft.PowerShell
             }
         }
 
+        // Helper method to get or create a command ID
+        private long GetOrCreateCommandId(SqliteConnection connection, string commandLine, string commandHash)
+        {
+            // First try to get existing command
+            using var selectCommand = connection.CreateCommand();
+            selectCommand.CommandText = "SELECT Id FROM Commands WHERE CommandHash = @CommandHash";
+            selectCommand.Parameters.AddWithValue("@CommandHash", commandHash);
+
+            var existingId = selectCommand.ExecuteScalar();
+            if (existingId != null)
+            {
+                return Convert.ToInt64(existingId);
+            }
+
+            // Insert new command
+            using var insertCommand = connection.CreateCommand();
+            insertCommand.CommandText = @"
+INSERT INTO Commands (CommandLine, CommandHash) 
+VALUES (@CommandLine, @CommandHash)
+RETURNING Id";
+            insertCommand.Parameters.AddWithValue("@CommandLine", commandLine);
+            insertCommand.Parameters.AddWithValue("@CommandHash", commandHash);
+
+            return Convert.ToInt64(insertCommand.ExecuteScalar());
+        }
+
+        // Helper method to get or create a location ID
+        private long GetOrCreateLocationId(SqliteConnection connection, string location)
+        {
+            // First try to get existing location
+            using var selectCommand = connection.CreateCommand();
+            selectCommand.CommandText = "SELECT Id FROM Locations WHERE Path = @Path";
+            selectCommand.Parameters.AddWithValue("@Path", location);
+
+            var existingId = selectCommand.ExecuteScalar();
+            if (existingId != null)
+            {
+                return Convert.ToInt64(existingId);
+            }
+
+            // Insert new location
+            using var insertCommand = connection.CreateCommand();
+            insertCommand.CommandText = @"
+INSERT INTO Locations (Path) 
+VALUES (@Path)
+RETURNING Id";
+            insertCommand.Parameters.AddWithValue("@Path", location);
+
+            return Convert.ToInt64(insertCommand.ExecuteScalar());
+        }
+
         private void WriteHistoryToSQLite(int start, int end)
         {
-            if (_historyFileMutex == null)
-            {
-                _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
-            }
+            _historyFileMutex ??= new Mutex(false, GetHistorySaveFileMutexName());
 
             WithHistoryFileMutexDo(1000, () =>
             {
@@ -382,12 +569,6 @@ namespace Microsoft.PowerShell
                     connection.Open();
 
                     using var transaction = connection.BeginTransaction();
-                    using var command = connection.CreateCommand();
-                    command.CommandText = "INSERT INTO History (CommandLine, StartTime, ElapsedTime, Location) VALUES (@CommandLine, @StartTime, @ElapsedTime, @Location)";
-                    command.Parameters.Add(new SqliteParameter("@CommandLine", string.Empty));
-                    command.Parameters.Add(new SqliteParameter("@StartTime", string.Empty));
-                    command.Parameters.Add(new SqliteParameter("@ElapsedTime", 0L));
-                    command.Parameters.Add(new SqliteParameter("@Location", string.Empty));
 
                     for (var i = start; i <= end; i++)
                     {
@@ -399,10 +580,33 @@ namespace Microsoft.PowerShell
                             continue;
                         }
 
-                        command.Parameters["@CommandLine"].Value = item.CommandLine;
-                        command.Parameters["@StartTime"].Value = item.StartTime.ToString("o");
-                        command.Parameters["@ElapsedTime"].Value = item.ApproximateElapsedTime.Ticks;
-                        command.Parameters["@Location"].Value = _engineIntrinsics?.SessionState?.Path?.CurrentLocation?.Path ?? "Unknown";
+                        // Generate command hash using SHA256
+                        string commandHash = ComputeCommandHash(item.CommandLine);
+                        string location = item.Location ?? _engineIntrinsics?.SessionState?.Path?.CurrentLocation?.Path ?? "Unknown";
+
+                        // Get or create command and location IDs
+                        long commandId = GetOrCreateCommandId(connection, item.CommandLine, commandHash);
+                        long locationId = GetOrCreateLocationId(connection, location);
+
+                        // Convert DateTime to Unix timestamp (INTEGER)
+                        long startTimeUnix = ((DateTimeOffset)item.StartTime).ToUnixTimeSeconds();
+                        long lastExecutedUnix = ((DateTimeOffset)DateTime.UtcNow).ToUnixTimeSeconds();
+
+                        // Insert or update execution history
+                        using var command = connection.CreateCommand();
+                        command.CommandText = @"
+INSERT INTO ExecutionHistory (CommandId, LocationId, StartTime, ElapsedTime, ExecutionCount, LastExecuted)
+VALUES (@CommandId, @LocationId, @StartTime, @ElapsedTime, 1, @LastExecuted)
+ON CONFLICT(CommandId, LocationId) DO UPDATE SET
+    ExecutionCount = ExecutionCount + 1,
+    LastExecuted = excluded.LastExecuted,
+    ElapsedTime = excluded.ElapsedTime";
+
+                        command.Parameters.AddWithValue("@CommandId", commandId);
+                        command.Parameters.AddWithValue("@LocationId", locationId);
+                        command.Parameters.AddWithValue("@StartTime", startTimeUnix);
+                        command.Parameters.AddWithValue("@ElapsedTime", item.ApproximateElapsedTime.Ticks);
+                        command.Parameters.AddWithValue("@LastExecuted", lastExecutedUnix);
                         command.ExecuteNonQuery();
                     }
 
@@ -413,6 +617,13 @@ namespace Microsoft.PowerShell
                     ReportHistoryFileError(e);
                 }
             });
+        }
+
+        private static string ComputeCommandHash(string command)
+        {
+            using var sha256 = System.Security.Cryptography.SHA256.Create();
+            byte[] hashBytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(command));
+            return BitConverter.ToString(hashBytes).Replace("-", "");
         }
 
         private void SaveHistoryAtExit()
@@ -585,11 +796,12 @@ namespace Microsoft.PowerShell
 
                 using (var command = connection.CreateCommand())
                 {
+                    // Use the HistoryView to get all the joined data, filtering by ExecutionHistory.Id
                     command.CommandText = @"
-                SELECT CommandLine, StartTime, ElapsedTime, Location
-                FROM History
-                WHERE Id > @LastId
-                ORDER BY Id ASC";
+SELECT CommandLine, StartTime, ElapsedTime, Location
+FROM HistoryView
+WHERE Id > @LastId
+ORDER BY Id ASC";
                     command.Parameters.AddWithValue("@LastId", _historyFileLastSavedSize);
 
                     using var reader = command.ExecuteReader();
@@ -598,7 +810,7 @@ namespace Microsoft.PowerShell
                         var item = new HistoryItem
                         {
                             CommandLine = reader.GetString(0),
-                            StartTime = DateTime.Parse(reader.GetString(1)),
+                            StartTime = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64(1)).DateTime,
                             ApproximateElapsedTime = TimeSpan.FromTicks(reader.GetInt64(2)),
                             Location = reader.GetString(3),
                             FromHistoryFile = true,
@@ -611,10 +823,10 @@ namespace Microsoft.PowerShell
                     }
                 }
 
-                // Update the last saved size to the latest ID in the database
+                // Update the last saved size to the latest ID in the ExecutionHistory table
                 using (var command = connection.CreateCommand())
                 {
-                    command.CommandText = "SELECT MAX(Id) FROM History";
+                    command.CommandText = "SELECT MAX(Id) FROM ExecutionHistory";
                     var result = command.ExecuteScalar();
                     if (result != DBNull.Value)
                     {
@@ -647,14 +859,8 @@ namespace Microsoft.PowerShell
                         {
                             foreach (var item in historyItems)
                             {
-                                // Use the full metadata from SQLite
-                                MaybeAddToHistory(
-                                    item.CommandLine,
-                                    item._edits ?? new List<EditItem> { EditItemInsertString.Create(item.CommandLine, 0) },
-                                    item._undoEditIndex,
-                                    item.Location,
-                                    fromDifferentSession: true,
-                                    fromInitialRead: false);
+                                _history.Enqueue(item);
+                                _currentHistoryIndex = _history.Count;
                             }
                         }
                     }
@@ -691,18 +897,30 @@ namespace Microsoft.PowerShell
                     connection.Open();
 
                     using var command = connection.CreateCommand();
-                    command.CommandText = @"
-                                SELECT CommandLine, StartTime, ElapsedTime, Location 
-                                FROM History 
-                                ORDER BY Id ASC";
 
+                    int limit = Options.MaximumHistoryCount switch
+                    {
+                        <= 10000 => 10000,   // Similar to 0.5MB text optimization
+                        <= 20000 => 20000,   // Similar to 1MB text optimization  
+                        _ => Options.MaximumHistoryCount
+                    };
+
+                    // Use the view for easy querying
+                    command.CommandText = @"
+SELECT CommandLine, StartTime, ElapsedTime, Location 
+FROM HistoryView 
+ORDER BY LastExecuted DESC
+LIMIT @Limit";
+                    command.Parameters.AddWithValue("@Limit", limit);
+
+                    var historyItems = new List<HistoryItem>();
                     using var reader = command.ExecuteReader();
                     while (reader.Read())
                     {
                         var item = new HistoryItem
                         {
                             CommandLine = reader.GetString(0),
-                            StartTime = DateTime.Parse(reader.GetString(1)),
+                            StartTime = DateTimeOffset.FromUnixTimeSeconds(reader.GetInt64(1)).DateTime,
                             ApproximateElapsedTime = TimeSpan.FromTicks(reader.GetInt64(2)),
                             Location = reader.GetString(3),
                             FromHistoryFile = true,
@@ -712,19 +930,23 @@ namespace Microsoft.PowerShell
                             _editGroupStart = -1
                         };
 
-                        // Add to the history queue.
+                        historyItems.Add(item);
+                    }
+
+                    historyItems.Reverse();
+
+                    foreach (var item in historyItems)
+                    {
                         _history.Enqueue(item);
                     }
 
                     // Update the last saved size to the latest ID in the database
-                    using (var idCommand = connection.CreateCommand())
+                    using var idCommand = connection.CreateCommand();
+                    idCommand.CommandText = "SELECT MAX(Id) FROM ExecutionHistory";
+                    var result = idCommand.ExecuteScalar();
+                    if (result != DBNull.Value)
                     {
-                        idCommand.CommandText = "SELECT MAX(Id) FROM History";
-                        var result = idCommand.ExecuteScalar();
-                        if (result != DBNull.Value)
-                        {
-                            _historyFileLastSavedSize = Convert.ToInt64(result);
-                        }
+                        _historyFileLastSavedSize = Convert.ToInt64(result);
                     }
                 }
                 catch (SqliteException ex)
@@ -750,54 +972,54 @@ namespace Microsoft.PowerShell
                     _historyFileLastSavedSize = fileInfo.Length;
                 });
             }
+        }
 
-            static IEnumerable<string> ReadHistoryLinesImpl(string path, int historyCount)
+        private IEnumerable<string> ReadHistoryLinesImpl(string path, int historyCount)
+        {
+            const long offset_1mb = 1048576;
+            const long offset_05mb = 524288;
+
+            // 1mb content contains more than 34,000 history lines for a typical usage, which should be
+            // more than enough to cover 20,000 history records (a history record could be a multi-line
+            // command). Similarly, 0.5mb content should be enough to cover 10,000 history records.
+            // We optimize the file reading when the history count falls in those ranges. If the history
+            // count is even larger, which should be very rare, we just read all lines.
+            long offset = historyCount switch
             {
-                const long offset_1mb = 1048576;
-                const long offset_05mb = 524288;
+                <= 10000 => offset_05mb,
+                <= 20000 => offset_1mb,
+                _ => 0,
+            };
 
-                // 1mb content contains more than 34,000 history lines for a typical usage, which should be
-                // more than enough to cover 20,000 history records (a history record could be a multi-line
-                // command). Similarly, 0.5mb content should be enough to cover 10,000 history records.
-                // We optimize the file reading when the history count falls in those ranges. If the history
-                // count is even larger, which should be very rare, we just read all lines.
-                long offset = historyCount switch
+            using var fs = new FileStream(path, FileMode.Open);
+            using var sr = new StreamReader(fs);
+
+            if (offset > 0 && fs.Length > offset)
+            {
+                // When the file size is larger than the offset, we only read that amount of content from the end.
+                fs.Seek(-offset, SeekOrigin.End);
+
+                // After seeking, the current position may point at the middle of a history record, or even at a
+                // byte within a UTF-8 character (history file is saved with UTF-8 encoding). So, let's ignore the
+                // first line read from that position.
+                sr.ReadLine();
+
+                string line;
+                while ((line = sr.ReadLine()) is not null)
                 {
-                    <= 10000 => offset_05mb,
-                    <= 20000 => offset_1mb,
-                    _ => 0,
-                };
-
-                using var fs = new FileStream(path, FileMode.Open);
-                using var sr = new StreamReader(fs);
-
-                if (offset > 0 && fs.Length > offset)
-                {
-                    // When the file size is larger than the offset, we only read that amount of content from the end.
-                    fs.Seek(-offset, SeekOrigin.End);
-
-                    // After seeking, the current position may point at the middle of a history record, or even at a
-                    // byte within a UTF-8 character (history file is saved with UTF-8 encoding). So, let's ignore the
-                    // first line read from that position.
-                    sr.ReadLine();
-
-                    string line;
-                    while ((line = sr.ReadLine()) is not null)
+                    if (!line.EndsWith("`", StringComparison.Ordinal))
                     {
-                        if (!line.EndsWith("`", StringComparison.Ordinal))
-                        {
-                            // A complete history record is guaranteed to start from the next line.
-                            break;
-                        }
+                        // A complete history record is guaranteed to start from the next line.
+                        break;
                     }
                 }
+            }
 
-                // Read lines in the streaming way, so it won't consume to much memory even if we have to
-                // read all lines from a large history file.
-                while (!sr.EndOfStream)
-                {
-                    yield return sr.ReadLine();
-                }
+            // Read lines in the streaming way, so it won't consume to much memory even if we have to
+            // read all lines from a large history file.
+            while (!sr.EndOfStream)
+            {
+                yield return sr.ReadLine();
             }
         }
 
@@ -1170,21 +1392,6 @@ namespace Microsoft.PowerShell
             }
         }
 
-        private int FindHistoryIndexByLocation(int startIndex, int direction)
-        {
-            int index = startIndex;
-            while (index >= 0 && index < _history.Count)
-            {
-                var currentLocation = _engineIntrinsics?.SessionState.Path.CurrentLocation.Path;
-                if (string.Equals(_history[index].Location, currentLocation, StringComparison.OrdinalIgnoreCase))
-                {
-                    return index;
-                }
-                index += direction;
-            }
-            return -1; // Not found
-        }
-
         private void HistoryRecall(int direction)
         {
             if (_recallHistoryCommandCount == 0 && LineIsMultiLine())
@@ -1203,14 +1410,8 @@ namespace Microsoft.PowerShell
             int newHistoryIndex = _currentHistoryIndex;
             while (count > 0)
             {
-                if (_options.HistoryType == HistoryType.SQLite)
-                {
-                    newHistoryIndex = FindHistoryIndexByLocation(newHistoryIndex + direction, direction);
-                }
-                else
-                {
-                    newHistoryIndex += direction;
-                }
+                newHistoryIndex += direction;
+
                 if (newHistoryIndex < 0 || newHistoryIndex >= _history.Count)
                 {
                     break;

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -321,7 +321,7 @@ JOIN Locations l ON eh.LocationId = l.Id;";
                 var historyLines = ReadHistoryLinesImpl(textHistoryPath, int.MaxValue);
                 var historyItems = new List<HistoryItem>();
 
-                // Convert text lines to HistoryItems
+                // Convert text lines to HistoryItems (collect without timestamps first)
                 var sb = new StringBuilder();
                 foreach (var line in historyLines)
                 {
@@ -336,7 +336,6 @@ JOIN Locations l ON eh.LocationId = l.Id;";
                         historyItems.Add(new HistoryItem
                         {
                             CommandLine = sb.ToString(),
-                            StartTime = DateTime.UtcNow.AddMinutes(-historyItems.Count), // Approximate timestamps
                             ApproximateElapsedTime = TimeSpan.Zero,
                             Location = "Unknown"
                         });
@@ -347,11 +346,20 @@ JOIN Locations l ON eh.LocationId = l.Id;";
                         historyItems.Add(new HistoryItem
                         {
                             CommandLine = line,
-                            StartTime = DateTime.UtcNow.AddMinutes(-historyItems.Count), // Approximate timestamps
                             ApproximateElapsedTime = TimeSpan.Zero,
                             Location = "Unknown"
                         });
                     }
+                }
+
+                // Assign timestamps AFTER collecting all items so that:
+                //   - oldest text line (index 0) gets the earliest timestamp
+                //   - newest text line (last index) gets the latest timestamp
+                //   - all migrated timestamps are older than "now"
+                var migrationBase = DateTime.UtcNow.AddMinutes(-(historyItems.Count + 1));
+                for (int idx = 0; idx < historyItems.Count; idx++)
+                {
+                    historyItems[idx].StartTime = migrationBase.AddMinutes(idx);
                 }
 
                 // Insert into SQLite database using the new normalized schema
@@ -827,6 +835,7 @@ ORDER BY Id ASC";
                             Location = reader.GetString(3),
                             FromHistoryFile = true,
                             FromOtherSession = true,
+                            _saved = true,
                             _edits = new List<EditItem> { EditItemInsertString.Create(reader.GetString(0), 0) },
                             _undoEditIndex = 1,
                             _editGroupStart = -1
@@ -937,6 +946,7 @@ LIMIT @Limit";
                             Location = reader.GetString(3),
                             FromHistoryFile = true,
                             FromOtherSession = fromOtherSession,
+                            _saved = true,
                             _edits = new List<EditItem> { EditItemInsertString.Create(reader.GetString(0), 0) },
                             _undoEditIndex = 1,
                             _editGroupStart = -1

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -209,7 +209,7 @@ namespace Microsoft.PowerShell
             return AddToHistoryOption.MemoryAndFile;
         }
 
-        private void InitializeSQLiteDatabase()
+        private void InitializeSQLiteDatabase(bool migrateTextHistory = false)
         {
             string baseConnectionString = $"Data Source={_options.HistorySavePath}";
             var connectionString = new SqliteConnectionStringBuilder(baseConnectionString)
@@ -288,8 +288,12 @@ JOIN Commands c ON eh.CommandId = c.Id
 JOIN Locations l ON eh.LocationId = l.Id;";
                     createTablesCommand.ExecuteNonQuery();
 
-                    // Migrate existing text file history if it exists
-                    MigrateTextHistoryToSQLite(connection);
+                    // Only migrate text history on initial Text -> SQLite switch,
+                    // not when relocating an existing SQLite database.
+                    if (migrateTextHistory)
+                    {
+                        MigrateTextHistoryToSQLite(connection);
+                    }
                 }
             }
             catch (SqliteException ex)
@@ -304,13 +308,9 @@ JOIN Locations l ON eh.LocationId = l.Id;";
 
         private void MigrateTextHistoryToSQLite(SqliteConnection connection)
         {
-            // Derive the text history path from the SQLite path.
-            // Both files share the same directory and host prefix:
-            //   ConsoleHost_history.txt  (text)
-            //   ConsoleHost_history.db   (SQLite)
-            // By the time this runs, HistorySavePath is already the .db path.
-            string textHistoryPath = Path.ChangeExtension(_options.HistorySavePath, ".txt");
-            if (!File.Exists(textHistoryPath))
+            // Use the dedicated text history path — no need to derive it from the SQLite path.
+            string textHistoryPath = _options.HistorySavePathText;
+            if (string.IsNullOrEmpty(textHistoryPath) || !File.Exists(textHistoryPath))
             {
                 return; // No text history to migrate
             }

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -289,7 +289,7 @@ JOIN Locations l ON eh.LocationId = l.Id;";
                     createTablesCommand.ExecuteNonQuery();
 
                     // Migrate existing text file history if it exists
-                    // MigrateTextHistoryToSQLite(connection);
+                    MigrateTextHistoryToSQLite(connection);
                 }
             }
             catch (SqliteException ex)
@@ -304,16 +304,15 @@ JOIN Locations l ON eh.LocationId = l.Id;";
 
         private void MigrateTextHistoryToSQLite(SqliteConnection connection)
         {
-            // Check if text history file exists
-            string textHistoryPath = _options.HistorySavePath.Replace(".sqlite", ".txt");
+            // Derive the text history path from the SQLite path.
+            // Both files share the same directory and host prefix:
+            //   ConsoleHost_history.txt  (text)
+            //   ConsoleHost_history.db   (SQLite)
+            // By the time this runs, HistorySavePath is already the .db path.
+            string textHistoryPath = Path.ChangeExtension(_options.HistorySavePath, ".txt");
             if (!File.Exists(textHistoryPath))
             {
-                // Try default history path pattern
-                textHistoryPath = Path.ChangeExtension(_options.HistorySavePath, ".txt");
-                if (!File.Exists(textHistoryPath))
-                {
-                    return; // No text history to migrate
-                }
+                return; // No text history to migrate
             }
 
             try
@@ -518,12 +517,15 @@ ON CONFLICT(CommandId, LocationId) DO UPDATE SET
             using var insertCommand = connection.CreateCommand();
             insertCommand.CommandText = @"
 INSERT INTO Commands (CommandLine, CommandHash) 
-VALUES (@CommandLine, @CommandHash)
-RETURNING Id";
+VALUES (@CommandLine, @CommandHash)";
             insertCommand.Parameters.AddWithValue("@CommandLine", commandLine);
             insertCommand.Parameters.AddWithValue("@CommandHash", commandHash);
+            insertCommand.ExecuteNonQuery();
 
-            return Convert.ToInt64(insertCommand.ExecuteScalar());
+            // Get the inserted row ID
+            using var lastIdCommand = connection.CreateCommand();
+            lastIdCommand.CommandText = "SELECT last_insert_rowid()";
+            return Convert.ToInt64(lastIdCommand.ExecuteScalar());
         }
 
         // Helper method to get or create a location ID
@@ -544,11 +546,14 @@ RETURNING Id";
             using var insertCommand = connection.CreateCommand();
             insertCommand.CommandText = @"
 INSERT INTO Locations (Path) 
-VALUES (@Path)
-RETURNING Id";
+VALUES (@Path)";
             insertCommand.Parameters.AddWithValue("@Path", location);
+            insertCommand.ExecuteNonQuery();
 
-            return Convert.ToInt64(insertCommand.ExecuteScalar());
+            // Get the inserted row ID
+            using var lastIdCommand = connection.CreateCommand();
+            lastIdCommand.CommandText = "SELECT last_insert_rowid()";
+            return Convert.ToInt64(lastIdCommand.ExecuteScalar());
         }
 
         private void WriteHistoryToSQLite(int start, int end)
@@ -1442,17 +1447,7 @@ LIMIT @Limit";
             }
             _recallHistoryCommandCount += 1;
 
-            // For SQLite/location-filtered history, allow returning to the current line
-            if (_options.HistoryType == HistoryType.SQLite &&
-                (newHistoryIndex < 0 || newHistoryIndex >= _history.Count))
-            {
-                _currentHistoryIndex = _history.Count;
-                var moveCursor = InViCommandMode() && !_options.HistorySearchCursorMovesToEnd
-                    ? HistoryMoveCursor.ToBeginning
-                    : HistoryMoveCursor.ToEnd;
-                UpdateFromHistory(moveCursor);
-            }
-            else if (newHistoryIndex >= 0 && newHistoryIndex <= _history.Count)
+            if (newHistoryIndex >= 0 && newHistoryIndex <= _history.Count)
             {
                 _currentHistoryIndex = newHistoryIndex;
                 var moveCursor = InViCommandMode() && !_options.HistorySearchCursorMovesToEnd

--- a/PSReadLine/History.cs
+++ b/PSReadLine/History.cs
@@ -633,7 +633,14 @@ ON CONFLICT(CommandId, LocationId) DO UPDATE SET
 
         private void SaveHistoryAtExit()
         {
-            WriteHistoryRange(0, _history.Count - 1, overwritten: true);
+            if (_options.HistoryType == HistoryType.SQLite)
+            {
+                WriteHistoryToSQLite(0, _history.Count - 1);
+            }
+            else
+            {
+                WriteHistoryRange(0, _history.Count - 1, overwritten: true);
+            }
         }
 
         private int historyErrorReportedCount;

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -43,6 +43,7 @@ namespace Microsoft.PowerShell
                     // For now remove all text history
                     _singleton._history?.Clear();
                     _singleton._currentHistoryIndex = 0;
+
                     ReadSQLiteHistory(fromOtherSession: false);
                 }
             }

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -26,6 +26,26 @@ namespace Microsoft.PowerShell
             {
                 Options.ContinuationPrompt = options.ContinuationPrompt;
             }
+            if (options._historyTypeSpecified)
+            {
+                Options.HistoryType = options.HistoryType;
+                if (Options.HistoryType is HistoryType.SQLite)
+                {
+                    Options.HistorySavePath = Options.SqliteHistorySavePath;
+                    // Check if the SQLite history file exists
+                    if (!string.IsNullOrEmpty(Options.HistorySavePath) && !System.IO.File.Exists(Options.HistorySavePath))
+                    {
+                        _historyFileMutex?.Dispose();
+                        _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
+                        InitializeSQLiteDatabase();
+                        _historyFileLastSavedSize = 0;
+                    }
+                    // For now remove all text history
+                    _singleton._history?.Clear();
+                    _singleton._currentHistoryIndex = 0;
+                    ReadSQLiteHistory(fromOtherSession: false);
+                }
+            }
             if (options._historyNoDuplicates.HasValue)
             {
                 Options.HistoryNoDuplicates = options.HistoryNoDuplicates;
@@ -127,7 +147,7 @@ namespace Microsoft.PowerShell
                 Options.HistorySavePath = options.HistorySavePath;
                 _historyFileMutex?.Dispose();
                 _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
-                _historyFileLastSavedSize = 0;
+                _historyFileLastSavedSize = 0;   
             }
             if (options._ansiEscapeTimeout.HasValue)
             {

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -31,16 +31,16 @@ namespace Microsoft.PowerShell
                 Options.HistoryType = options.HistoryType;
                 if (Options.HistoryType is HistoryType.SQLite)
                 {
-                    Options.HistorySavePath = Options.SqliteHistorySavePath;
-                    // Check if the SQLite history file exists
+                    // HistorySavePath is now computed from HistoryType, so it already
+                    // points at HistorySavePathSQLite after the type switch above.
                     if (!string.IsNullOrEmpty(Options.HistorySavePath) && !System.IO.File.Exists(Options.HistorySavePath))
                     {
                         _historyFileMutex?.Dispose();
                         _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
-                        InitializeSQLiteDatabase();
+                        InitializeSQLiteDatabase(migrateTextHistory: true);
                         _historyFileLastSavedSize = 0;
                     }
-                    // For now remove all text history
+                    // Clear text history from memory and load SQLite history
                     _singleton._history?.Clear();
                     _singleton._currentHistoryIndex = 0;
 
@@ -143,12 +143,38 @@ namespace Microsoft.PowerShell
                 }
                 Options.ViModeChangeHandler = options.ViModeChangeHandler;
             }
-            if (options.HistorySavePath != null)
+            if (options.HistorySavePathText != null)
             {
-                Options.HistorySavePath = options.HistorySavePath;
-                _historyFileMutex?.Dispose();
-                _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
-                _historyFileLastSavedSize = 0;   
+                Options.HistorySavePathText = options.HistorySavePathText;
+
+                // If currently in Text mode, reset the mutex for the new active path.
+                if (Options.HistoryType is HistoryType.Text)
+                {
+                    _historyFileMutex?.Dispose();
+                    _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
+                    _historyFileLastSavedSize = 0;
+                }
+            }
+            if (options.HistorySavePathSQLite != null)
+            {
+                Options.HistorySavePathSQLite = options.HistorySavePathSQLite;
+
+                // If currently in SQLite mode, reconnect to the new database.
+                if (Options.HistoryType is HistoryType.SQLite)
+                {
+                    _historyFileMutex?.Dispose();
+                    _historyFileMutex = new Mutex(false, GetHistorySaveFileMutexName());
+                    _historyFileLastSavedSize = 0;
+
+                    if (!System.IO.File.Exists(Options.HistorySavePath))
+                    {
+                        InitializeSQLiteDatabase();
+                    }
+
+                    _singleton._history?.Clear();
+                    _singleton._currentHistoryIndex = 0;
+                    ReadSQLiteHistory(fromOtherSession: false);
+                }
             }
             if (options._ansiEscapeTimeout.HasValue)
             {

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -40,11 +40,17 @@ namespace Microsoft.PowerShell
                         InitializeSQLiteDatabase(migrateTextHistory: true);
                         _historyFileLastSavedSize = 0;
                     }
-                    // Clear text history from memory and load SQLite history
-                    _singleton._history?.Clear();
-                    _singleton._currentHistoryIndex = 0;
 
-                    ReadSQLiteHistory(fromOtherSession: false);
+                    // _history is null when Set-PSReadLineOption runs from the profile before
+                    // the first ReadLine() call. In that case, skip loading here — ReadLine()
+                    // initialization will create _history and load SQLite history itself.
+                    // When _history already exists (interactive switch), reload immediately.
+                    if (_singleton._history != null)
+                    {
+                        _singleton._history.Clear();
+                        _singleton._currentHistoryIndex = 0;
+                        ReadSQLiteHistory(fromOtherSession: false);
+                    }
                 }
             }
             if (options._historyNoDuplicates.HasValue)
@@ -171,9 +177,12 @@ namespace Microsoft.PowerShell
                         InitializeSQLiteDatabase();
                     }
 
-                    _singleton._history?.Clear();
-                    _singleton._currentHistoryIndex = 0;
-                    ReadSQLiteHistory(fromOtherSession: false);
+                    if (_singleton._history != null)
+                    {
+                        _singleton._history.Clear();
+                        _singleton._currentHistoryIndex = 0;
+                        ReadSQLiteHistory(fromOtherSession: false);
+                    }
                 }
             }
             if (options._ansiEscapeTimeout.HasValue)

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -13,6 +13,8 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>9.0</LangVersion>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,7 +22,9 @@
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
     <PackageReference Include="Microsoft.PowerShell.Pager" Version="1.0.0" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
   </ItemGroup>
 
   <ItemGroup>
@@ -29,5 +33,6 @@
     <None Include="PSReadLine.format.ps1xml" CopyToOutputDirectory="PreserveNewest" />
     <None Include="SamplePSReadLineProfile.ps1" />
     <None Include="Changes.txt" />
+    <None Update="runtimes/**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -24,14 +24,6 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
     <PackageReference Include="Microsoft.PowerShell.Pager" Version="1.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
-    
-    <!-- Platform-specific SQLite bundles -->
-    <!-- Use Windows system SQLite on Windows -->
-    <PackageReference Include="SQLitePCLRaw.bundle_winsqlite3" Version="2.1.11" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
-    <!-- Use embedded SQLite with all native libraries for Linux/macOS -->
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
-    
-    <ProjectReference Include="..\Polyfill\Polyfill.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -32,6 +32,5 @@
     <None Include="PSReadLine.format.ps1xml" CopyToOutputDirectory="PreserveNewest" />
     <None Include="SamplePSReadLineProfile.ps1" />
     <None Include="Changes.txt" />
-    <None Update="runtimes/**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/PSReadLine/PSReadLine.csproj
+++ b/PSReadLine/PSReadLine.csproj
@@ -14,7 +14,6 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
     <LangVersion>9.0</LangVersion>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +24,14 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.4" />
     <PackageReference Include="Microsoft.PowerShell.Pager" Version="1.0.0" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" />
+    
+    <!-- Platform-specific SQLite bundles -->
+    <!-- Use Windows system SQLite on Windows -->
+    <PackageReference Include="SQLitePCLRaw.bundle_winsqlite3" Version="2.1.11" Condition="$([MSBuild]::IsOSPlatform('Windows'))" />
+    <!-- Use embedded SQLite with all native libraries for Linux/macOS -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.11" Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
+    
+    <ProjectReference Include="..\Polyfill\Polyfill.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -90,6 +90,9 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
               <ListItem>
                 <PropertyName>EditMode</PropertyName>
               </ListItem>
+			  <ListItem>
+				<PropertyName>HistoryType</PropertyName>
+			  </ListItem>
               <ListItem>
                 <PropertyName>AddToHistoryHandler</PropertyName>
               </ListItem>

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -100,7 +100,10 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>HistoryNoDuplicates</PropertyName>
               </ListItem>
               <ListItem>
-                <PropertyName>HistorySavePath</PropertyName>
+                <PropertyName>HistorySavePathText</PropertyName>
+              </ListItem>
+              <ListItem>
+                <PropertyName>HistorySavePathSQLite</PropertyName>
               </ListItem>
               <ListItem>
                 <PropertyName>HistorySaveStyle</PropertyName>

--- a/PSReadLine/Prediction.cs
+++ b/PSReadLine/Prediction.cs
@@ -57,6 +57,11 @@ namespace Microsoft.PowerShell
             }
         }
 
+        private static string GetCurrentLocation(EngineIntrinsics engineIntrinsics)
+        {
+            return engineIntrinsics?.SessionState?.Path?.CurrentLocation?.Path ?? "Unknown";
+        }
+
         // Stub helper methods so prediction can be mocked
         [ExcludeFromCodeCoverage]
         Task<List<PredictionResult>> IPSConsoleReadLineMockableMethods.PredictInputAsync(Ast ast, Token[] tokens)

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -927,10 +927,6 @@ namespace Microsoft.PowerShell
             {
                 ReadHistoryFile();
             }
-            else if (readHistoryFile && _options.HistoryType == HistoryType.SQLite)
-            {
-                ReadSQLiteHistory(fromOtherSession: false);
-            }
 
             _killIndex = -1; // So first add indexes 0.
             _killRing = new List<string>(Options.MaximumKillRingCount);

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -567,7 +567,15 @@ namespace Microsoft.PowerShell
                 if (_inputAccepted)
                 {
                     _acceptedCommandLine = _buffer.ToString();
-                    MaybeAddToHistory(_acceptedCommandLine, _edits, _undoEditIndex);
+                    if (_options.HistoryType == HistoryType.SQLite)
+                    {
+                        string location = _engineIntrinsics?.SessionState?.Path?.CurrentLocation?.Path;
+                        MaybeAddToHistory(_acceptedCommandLine, _edits, _undoEditIndex, location);
+                    }
+                    else
+                    {
+                        MaybeAddToHistory(_acceptedCommandLine, _edits, _undoEditIndex);
+                    }
 
                     _prediction.OnCommandLineAccepted(_acceptedCommandLine);
                     return _acceptedCommandLine;
@@ -915,9 +923,13 @@ namespace Microsoft.PowerShell
             {
             }
 
-            if (readHistoryFile)
+            if (readHistoryFile && _options.HistoryType == HistoryType.Text)
             {
                 ReadHistoryFile();
+            }
+            else if (readHistoryFile && _options.HistoryType == HistoryType.SQLite)
+            {
+                ReadSQLiteHistory(fromOtherSession: false);
             }
 
             _killIndex = -1; // So first add indexes 0.

--- a/PSReadLine/ReadLine.cs
+++ b/PSReadLine/ReadLine.cs
@@ -928,6 +928,11 @@ namespace Microsoft.PowerShell
                 ReadHistoryFile();
             }
 
+            if (readHistoryFile && _options.HistoryType == HistoryType.SQLite)
+            {
+                ReadSQLiteHistory(fromOtherSession: false);
+            }
+
             _killIndex = -1; // So first add indexes 0.
             _killRing = new List<string>(Options.MaximumKillRingCount);
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
-    <add key="PowerShell_PublicPackages" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v3/index.json" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -40,7 +40,8 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             string historySavingFile = Path.GetTempFileName();
-            var options = new SetPSReadLineOption {
+            var options = new SetPSReadLineOption
+            {
                 HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
                 MaximumHistoryCount = 3,
             };
@@ -756,48 +757,53 @@ namespace Test
             SetHistory();
             Test(" ", Keys(' ', _.UpArrow, _.DownArrow));
 
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {HistorySearchCursorMovesToEnd = false});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistorySearchCursorMovesToEnd = false });
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
 
             SetHistory("dosomething", "ps p*", "dir", "echo zzz");
             Test("dosomething", Keys(
                 "d",
-                _.UpArrow,   CheckThat(() => {
+                _.UpArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "ir");
                     AssertCursorLeftIs(1);
                 }),
-                _.UpArrow,   CheckThat(() => {
+                _.UpArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "osomething");
                     AssertCursorLeftIs(1);
-            })));
+                })));
 
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {HistorySearchCursorMovesToEnd = true});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistorySearchCursorMovesToEnd = true });
             SetHistory("dosomething", "ps p*", "dir", "echo zzz");
             Test("dosomething", Keys(
                 "d",
-                _.UpArrow,   CheckThat(() => {
+                _.UpArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "ir");
                     AssertCursorLeftIs(3);
                 }),
-                _.UpArrow,   CheckThat(() => {
+                _.UpArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "osomething");
                     AssertCursorLeftIs(11);
                 }),
-                _.DownArrow, CheckThat(() => {
+                _.DownArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "ir");
                     AssertCursorLeftIs(3);
                 }),
-                _.UpArrow,   CheckThat(() =>
+                _.UpArrow, CheckThat(() =>
                 {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
@@ -813,31 +819,34 @@ namespace Test
                       new KeyHandler("UpArrow", PSConsoleReadLine.HistorySearchBackward),
                       new KeyHandler("DownArrow", PSConsoleReadLine.HistorySearchForward));
 
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {HistorySearchCursorMovesToEnd = true});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistorySearchCursorMovesToEnd = true });
             var emphasisColors = Tuple.Create(PSConsoleReadLineOptions.DefaultEmphasisColor, _console.BackgroundColor);
 
             SetHistory("dosomething", "ps p*", "dir", "echo zzz");
             Test("dosomething", Keys(
                 "d",
-                _.UpArrow,   CheckThat(() => {
+                _.UpArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "ir");
                     AssertCursorLeftIs(3);
                 }),
-                _.UpArrow,   CheckThat(() => {
+                _.UpArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "osomething");
                     AssertCursorLeftIs(11);
                 }),
-                _.DownArrow, CheckThat(() => {
+                _.DownArrow, CheckThat(() =>
+                {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
                         TokenClassification.Command, "ir");
                     AssertCursorLeftIs(3);
                 }),
-                _.UpArrow,   CheckThat(() =>
+                _.UpArrow, CheckThat(() =>
                 {
                     AssertScreenIs(1,
                         emphasisColors, 'd',
@@ -1122,7 +1131,7 @@ namespace Test
         public void AddToHistoryHandler()
         {
             TestSetup(KeyMode.Cmd);
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {AddToHistoryHandler = s => s.StartsWith("z")});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { AddToHistoryHandler = s => s.StartsWith("z") });
 
             SetHistory("zzzz", "azzz");
             Test("zzzz", Keys(_.UpArrow));
@@ -1132,14 +1141,14 @@ namespace Test
         public void HistoryNoDuplicates()
         {
             TestSetup(KeyMode.Cmd);
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {HistoryNoDuplicates = false});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistoryNoDuplicates = false });
 
             SetHistory("zzzz", "aaaa", "bbbb", "bbbb", "cccc");
             Assert.Equal(5, PSConsoleReadLine.GetHistoryItems().Length);
             Test("aaaa", Keys(Enumerable.Repeat(_.UpArrow, 4)));
 
             // Changing the option should affect existing history.
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {HistoryNoDuplicates = true});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistoryNoDuplicates = true });
             Test("zzzz", Keys(Enumerable.Repeat(_.UpArrow, 4)));
 
             SetHistory("aaaa", "bbbb", "bbbb", "cccc");
@@ -1164,7 +1173,7 @@ namespace Test
                       new KeyHandler("UpArrow", PSConsoleReadLine.HistorySearchBackward),
                       new KeyHandler("DownArrow", PSConsoleReadLine.HistorySearchForward));
 
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {HistoryNoDuplicates = true});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistoryNoDuplicates = true });
             SetHistory("0000", "echo aaaa", "1111", "echo bbbb", "2222", "echo bbbb", "3333", "echo cccc", "4444");
             Test("echo aaaa", Keys("echo", Enumerable.Repeat(_.UpArrow, 3)));
 
@@ -1180,7 +1189,7 @@ namespace Test
         {
             TestSetup(KeyMode.Emacs);
 
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {HistoryNoDuplicates = true});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistoryNoDuplicates = true });
             SetHistory("0000", "echo aaaa", "1111", "echo bbbb", "2222", "echo bbbb", "3333", "echo cccc", "4444");
             Test("echo aaaa", Keys(
                 _.Ctrl_r, "echo", _.Ctrl_r, _.Ctrl_r));
@@ -1203,7 +1212,7 @@ namespace Test
 
             // There should be 4 items in history, the following should remove the
             // oldest history item.
-            PSConsoleReadLine.SetOptions(new SetPSReadLineOption {MaximumHistoryCount = 3});
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { MaximumHistoryCount = 3 });
             Test("aaaa", Keys(Enumerable.Repeat(_.UpArrow, 4)));
 
             Test("zzzz", Keys("zzzz"));
@@ -1212,5 +1221,30 @@ namespace Test
             Test("cccc", Keys("cccc"));
             Test("aaaa", Keys(Enumerable.Repeat(_.UpArrow, 4)));
         }
+
+        [SkippableFact]
+        public void SetPSReadLineOption_HistoryType_AcceptsSQLite()
+        {
+            var method = typeof(PSConsoleReadLine).GetMethod("SetOptions");
+            Assert.NotNull(method);
+
+            var optionsType = typeof(SetPSReadLineOption);
+            var historyTypeProperty = optionsType.GetProperty("HistoryType");
+            Assert.NotNull(historyTypeProperty);
+
+            var options = new SetPSReadLineOption();
+            historyTypeProperty.SetValue(options, HistoryType.SQLite);
+
+            Exception ex = Record.Exception(() => PSConsoleReadLine.SetOptions(options));
+            Assert.Null(ex);
+
+            Assert.Equal(HistoryType.SQLite, historyTypeProperty.GetValue(options));
+
+            // Set the history type back to the default.
+            historyTypeProperty.SetValue(options, HistoryType.Text);
+            Assert.Equal(HistoryType.Text, historyTypeProperty.GetValue(options));
+        }
+
+        
     }
 }

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -1221,30 +1221,5 @@ namespace Test
             Test("cccc", Keys("cccc"));
             Test("aaaa", Keys(Enumerable.Repeat(_.UpArrow, 4)));
         }
-
-        [SkippableFact]
-        public void SetPSReadLineOption_HistoryType_AcceptsSQLite()
-        {
-            var method = typeof(PSConsoleReadLine).GetMethod("SetOptions");
-            Assert.NotNull(method);
-
-            var optionsType = typeof(SetPSReadLineOption);
-            var historyTypeProperty = optionsType.GetProperty("HistoryType");
-            Assert.NotNull(historyTypeProperty);
-
-            var options = new SetPSReadLineOption();
-            historyTypeProperty.SetValue(options, HistoryType.SQLite);
-
-            Exception ex = Record.Exception(() => PSConsoleReadLine.SetOptions(options));
-            Assert.Null(ex);
-
-            Assert.Equal(HistoryType.SQLite, historyTypeProperty.GetValue(options));
-
-            // Set the history type back to the default.
-            historyTypeProperty.SetValue(options, HistoryType.Text);
-            Assert.Equal(HistoryType.Text, historyTypeProperty.GetValue(options));
-        }
-
-        
     }
 }

--- a/test/HistoryTest.cs
+++ b/test/HistoryTest.cs
@@ -47,7 +47,7 @@ namespace Test
             };
 
             typeof(SetPSReadLineOption)
-                .GetField("_historySavePath", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetField("_historySavePathText", BindingFlags.Instance | BindingFlags.NonPublic)
                 .SetValue(options, historySavingFile);
 
             PSConsoleReadLine.SetOptions(options);
@@ -99,7 +99,7 @@ namespace Test
             Test("", Keys(_.UpArrow, _.DownArrow));
 
             var options = PSConsoleReadLine.GetOptions();
-            var oldHistoryFilePath = options.HistorySavePath;
+            var oldHistoryFilePath = options.HistorySavePathText;
             var oldHistorySaveStyle = options.HistorySaveStyle;
 
             // AddToHistoryHandler should be set to the default handler.
@@ -136,7 +136,7 @@ namespace Test
 
             try
             {
-                options.HistorySavePath = newHistoryFilePath;
+                options.HistorySavePathText = newHistoryFilePath;
                 options.HistorySaveStyle = newHistorySaveStyle;
                 SetHistory(expectedHistoryItems);
 
@@ -158,7 +158,7 @@ namespace Test
             }
             finally
             {
-                options.HistorySavePath = oldHistoryFilePath;
+                options.HistorySavePathText = oldHistoryFilePath;
                 options.HistorySaveStyle = oldHistorySaveStyle;
                 File.Delete(newHistoryFilePath);
             }
@@ -173,7 +173,7 @@ namespace Test
             SetHistory();
 
             var options = PSConsoleReadLine.GetOptions();
-            var oldHistoryFilePath = options.HistorySavePath;
+            var oldHistoryFilePath = options.HistorySavePathText;
             var oldHistorySaveStyle = options.HistorySaveStyle;
 
             // AddToHistoryHandler should be set to the default handler.
@@ -253,7 +253,7 @@ namespace Test
 
             try
             {
-                options.HistorySavePath = newHistoryFilePath;
+                options.HistorySavePathText = newHistoryFilePath;
                 options.HistorySaveStyle = newHistorySaveStyle;
                 SetHistory(expectedHistoryItems);
 
@@ -275,7 +275,7 @@ namespace Test
             }
             finally
             {
-                options.HistorySavePath = oldHistoryFilePath;
+                options.HistorySavePathText = oldHistoryFilePath;
                 options.HistorySaveStyle = oldHistorySaveStyle;
                 File.Delete(newHistoryFilePath);
             }
@@ -291,7 +291,7 @@ namespace Test
             Test("", Keys(_.UpArrow, _.DownArrow));
 
             var options = PSConsoleReadLine.GetOptions();
-            var oldHistoryFilePath = options.HistorySavePath;
+            var oldHistoryFilePath = options.HistorySavePathText;
             var oldHistorySaveStyle = options.HistorySaveStyle;
 
             // AddToHistoryHandler should be set to the default handler.
@@ -328,7 +328,7 @@ namespace Test
 
             try
             {
-                options.HistorySavePath = newHistoryFilePath;
+                options.HistorySavePathText = newHistoryFilePath;
                 options.HistorySaveStyle = newHistorySaveStyle;
 
                 //
@@ -417,7 +417,7 @@ namespace Test
             }
             finally
             {
-                options.HistorySavePath = oldHistoryFilePath;
+                options.HistorySavePathText = oldHistoryFilePath;
                 options.HistorySaveStyle = oldHistorySaveStyle;
                 options.AddToHistoryHandler = PSConsoleReadLineOptions.DefaultAddToHistoryHandler;
                 File.Delete(newHistoryFilePath);
@@ -434,7 +434,7 @@ namespace Test
             Test("", Keys(_.UpArrow, _.DownArrow));
 
             var options = PSConsoleReadLine.GetOptions();
-            var oldHistoryFilePath = options.HistorySavePath;
+            var oldHistoryFilePath = options.HistorySavePathText;
             var oldHistorySaveStyle = options.HistorySaveStyle;
 
             // AddToHistoryHandler should be set to the default handler.
@@ -481,7 +481,7 @@ namespace Test
 
             try
             {
-                options.HistorySavePath = newHistoryFilePath;
+                options.HistorySavePathText = newHistoryFilePath;
                 options.HistorySaveStyle = newHistorySaveStyle;
 
                 //
@@ -570,7 +570,7 @@ namespace Test
             }
             finally
             {
-                options.HistorySavePath = oldHistoryFilePath;
+                options.HistorySavePathText = oldHistoryFilePath;
                 options.HistorySaveStyle = oldHistorySaveStyle;
                 options.AddToHistoryHandler = PSConsoleReadLineOptions.DefaultAddToHistoryHandler;
                 File.Delete(newHistoryFilePath);

--- a/test/SQLiteHistoryTest.cs
+++ b/test/SQLiteHistoryTest.cs
@@ -20,16 +20,20 @@ namespace Test
             var options = PSConsoleReadLine.GetOptions();
             var ctx = new SQLiteTestContext
             {
-                OriginalHistorySavePath = options.HistorySavePath,
-                OriginalSqliteHistorySavePath = options.SqliteHistorySavePath,
+                OriginalHistorySavePathText = options.HistorySavePathText,
+                OriginalHistorySavePathSQLite = options.HistorySavePathSQLite,
                 OriginalHistorySaveStyle = options.HistorySaveStyle,
                 OriginalHistoryType = options.HistoryType,
                 TempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db"),
             };
 
-            // Point SqliteHistorySavePath to our temp DB before switching mode,
-            // because SetOptionsInternal reads SqliteHistorySavePath when HistoryType is set to SQLite.
-            options.SqliteHistorySavePath = ctx.TempDbPath;
+            // Point HistorySavePathSQLite to our temp DB before switching mode,
+            // because SetOptionsInternal reads HistorySavePathSQLite when HistoryType is set to SQLite.
+            options.HistorySavePathSQLite = ctx.TempDbPath;
+
+            // Point HistorySavePathText to a non-existent file so migration doesn't
+            // accidentally pull from the real production text history.
+            options.HistorySavePathText = Path.ChangeExtension(ctx.TempDbPath, ".txt");
 
             // Switch to SQLite mode — this creates the DB and clears in-memory history.
             var setOptions = new SetPSReadLineOption
@@ -47,8 +51,8 @@ namespace Test
         /// </summary>
         private class SQLiteTestContext : IDisposable
         {
-            public string OriginalHistorySavePath;
-            public string OriginalSqliteHistorySavePath;
+            public string OriginalHistorySavePathText;
+            public string OriginalHistorySavePathSQLite;
             public HistorySaveStyle OriginalHistorySaveStyle;
             public HistoryType OriginalHistoryType;
             public string TempDbPath;
@@ -58,8 +62,8 @@ namespace Test
                 var options = PSConsoleReadLine.GetOptions();
 
                 // Restore original settings
-                options.SqliteHistorySavePath = OriginalSqliteHistorySavePath;
-                options.HistorySavePath = OriginalHistorySavePath;
+                options.HistorySavePathSQLite = OriginalHistorySavePathSQLite;
+                options.HistorySavePathText = OriginalHistorySavePathText;
                 options.HistorySaveStyle = OriginalHistorySaveStyle;
                 options.HistoryType = OriginalHistoryType;
 
@@ -223,8 +227,8 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             var options = PSConsoleReadLine.GetOptions();
-            var originalHistorySavePath = options.HistorySavePath;
-            var originalSqliteHistorySavePath = options.SqliteHistorySavePath;
+            var originalHistorySavePathText = options.HistorySavePathText;
+            var originalHistorySavePathSQLite = options.HistorySavePathSQLite;
             var originalHistorySaveStyle = options.HistorySaveStyle;
             var originalHistoryType = options.HistoryType;
 
@@ -241,8 +245,9 @@ namespace Test
                     "echo hello"
                 });
 
-                // Set up SQLite mode pointing at the temp path
-                options.SqliteHistorySavePath = tempDbPath;
+                // Point both paths so migration can find the text file
+                options.HistorySavePathText = tempTxtPath;
+                options.HistorySavePathSQLite = tempDbPath;
 
                 var setOptions = new SetPSReadLineOption
                 {
@@ -264,8 +269,8 @@ namespace Test
             finally
             {
                 // Restore original settings
-                options.SqliteHistorySavePath = originalSqliteHistorySavePath;
-                options.HistorySavePath = originalHistorySavePath;
+                options.HistorySavePathSQLite = originalHistorySavePathSQLite;
+                options.HistorySavePathText = originalHistorySavePathText;
                 options.HistorySaveStyle = originalHistorySaveStyle;
                 options.HistoryType = originalHistoryType;
                 PSConsoleReadLine.ClearHistory();
@@ -281,8 +286,8 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             var options = PSConsoleReadLine.GetOptions();
-            var originalHistorySavePath = options.HistorySavePath;
-            var originalSqliteHistorySavePath = options.SqliteHistorySavePath;
+            var originalHistorySavePathText = options.HistorySavePathText;
+            var originalHistorySavePathSQLite = options.HistorySavePathSQLite;
             var originalHistorySaveStyle = options.HistorySaveStyle;
             var originalHistoryType = options.HistoryType;
 
@@ -291,7 +296,9 @@ namespace Test
 
             try
             {
-                options.SqliteHistorySavePath = tempDbPath;
+                options.HistorySavePathSQLite = tempDbPath;
+                // Point text path to a non-existent file so migration won't import from the real history.
+                options.HistorySavePathText = Path.ChangeExtension(tempDbPath, ".txt");
 
                 var setOptions = new SetPSReadLineOption
                 {
@@ -310,8 +317,8 @@ namespace Test
             }
             finally
             {
-                options.SqliteHistorySavePath = originalSqliteHistorySavePath;
-                options.HistorySavePath = originalHistorySavePath;
+                options.HistorySavePathSQLite = originalHistorySavePathSQLite;
+                options.HistorySavePathText = originalHistorySavePathText;
                 options.HistorySaveStyle = originalHistorySaveStyle;
                 options.HistoryType = originalHistoryType;
                 PSConsoleReadLine.ClearHistory();
@@ -326,8 +333,8 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             var options = PSConsoleReadLine.GetOptions();
-            var originalHistorySavePath = options.HistorySavePath;
-            var originalSqliteHistorySavePath = options.SqliteHistorySavePath;
+            var originalHistorySavePathText = options.HistorySavePathText;
+            var originalHistorySavePathSQLite = options.HistorySavePathSQLite;
             var originalHistorySaveStyle = options.HistorySaveStyle;
             var originalHistoryType = options.HistoryType;
 
@@ -340,7 +347,8 @@ namespace Test
                 File.WriteAllLines(tempTxtPath, new[] { "cmd1", "cmd2" });
 
                 // First switch to SQLite - should migrate
-                options.SqliteHistorySavePath = tempDbPath;
+                options.HistorySavePathText = tempTxtPath;
+                options.HistorySavePathSQLite = tempDbPath;
                 var setOptions = new SetPSReadLineOption
                 {
                     HistoryType = HistoryType.SQLite,
@@ -367,8 +375,8 @@ namespace Test
             }
             finally
             {
-                options.SqliteHistorySavePath = originalSqliteHistorySavePath;
-                options.HistorySavePath = originalHistorySavePath;
+                options.HistorySavePathSQLite = originalHistorySavePathSQLite;
+                options.HistorySavePathText = originalHistorySavePathText;
                 options.HistorySaveStyle = originalHistorySaveStyle;
                 options.HistoryType = originalHistoryType;
                 PSConsoleReadLine.ClearHistory();
@@ -411,14 +419,14 @@ namespace Test
             TestSetup(KeyMode.Cmd);
 
             var psrlOptions = PSConsoleReadLine.GetOptions();
-            var originalSqlitePath = psrlOptions.SqliteHistorySavePath;
-            var originalHistorySavePath = psrlOptions.HistorySavePath;
+            var originalSqlitePath = psrlOptions.HistorySavePathSQLite;
+            var originalHistorySavePathText = psrlOptions.HistorySavePathText;
             var originalHistoryType = psrlOptions.HistoryType;
             var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
 
             try
             {
-                psrlOptions.SqliteHistorySavePath = tempDbPath;
+                psrlOptions.HistorySavePathSQLite = tempDbPath;
 
                 var optionsType = typeof(SetPSReadLineOption);
                 var historyTypeProperty = optionsType.GetProperty("HistoryType");
@@ -438,8 +446,8 @@ namespace Test
             }
             finally
             {
-                psrlOptions.SqliteHistorySavePath = originalSqlitePath;
-                psrlOptions.HistorySavePath = originalHistorySavePath;
+                psrlOptions.HistorySavePathSQLite = originalSqlitePath;
+                psrlOptions.HistorySavePathText = originalHistorySavePathText;
                 psrlOptions.HistoryType = originalHistoryType;
                 PSConsoleReadLine.ClearHistory();
                 try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }

--- a/test/SQLiteHistoryTest.cs
+++ b/test/SQLiteHistoryTest.cs
@@ -115,6 +115,29 @@ namespace Test
             return results.ToArray();
         }
 
+        /// <summary>
+        /// Helper to query command lines with timestamps and execution counts from the SQLite database.
+        /// </summary>
+        private (string CommandLine, long LastExecuted, long ExecutionCount)[] QuerySQLiteHistoryWithTimestamps(string dbPath)
+        {
+            var connectionString = new SqliteConnectionStringBuilder($"Data Source={dbPath}")
+            {
+                Mode = SqliteOpenMode.ReadOnly
+            }.ToString();
+
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT CommandLine, LastExecuted, ExecutionCount FROM HistoryView ORDER BY LastExecuted ASC";
+            using var reader = cmd.ExecuteReader();
+            var results = new System.Collections.Generic.List<(string CommandLine, long LastExecuted, long ExecutionCount)>();
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetInt64(1), reader.GetInt64(2)));
+            }
+            return results.ToArray();
+        }
+
         // =====================================================================
         // SQLite Database Persistence Tests
         // =====================================================================
@@ -407,6 +430,262 @@ namespace Test
             // Verify both commands appear in ExecutionHistory
             long ehCount = CountSQLiteRows(ctx.TempDbPath, "ExecutionHistory");
             Assert.Equal(2, ehCount);
+        }
+
+        // =====================================================================
+        // Migration Timestamp Ordering Tests (Bug Fix)
+        // =====================================================================
+
+        /// <summary>
+        /// After migration, timestamps must be chronological (oldest text line = earliest time)
+        /// and all must be older than UtcNow.
+        /// Bug: Previously, timestamps were assigned during collection using
+        /// DateTime.UtcNow.AddMinutes(-historyItems.Count), which gave the first text line
+        /// (oldest) the newest timestamp and the last text line (newest) the oldest timestamp.
+        /// </summary>
+        [SkippableFact]
+        public void SQLiteHistory_MigrationTimestampsAreChronologicalAndOlderThanNow()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var options = PSConsoleReadLine.GetOptions();
+            var originalHistorySavePathText = options.HistorySavePathText;
+            var originalHistorySavePathSQLite = options.HistorySavePathSQLite;
+            var originalHistorySaveStyle = options.HistorySaveStyle;
+            var originalHistoryType = options.HistoryType;
+
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+            var tempTxtPath = Path.ChangeExtension(tempDbPath, ".txt");
+
+            try
+            {
+                // Create text history with known ordering: "first" is oldest, "third" is newest
+                File.WriteAllLines(tempTxtPath, new[] { "first", "second", "third" });
+
+                options.HistorySavePathText = tempTxtPath;
+                options.HistorySavePathSQLite = tempDbPath;
+
+                var setOptions = new SetPSReadLineOption
+                {
+                    HistoryType = HistoryType.SQLite,
+                    HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+                };
+                PSConsoleReadLine.SetOptions(setOptions);
+
+                var nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+                // Query timestamps from DB in insertion order
+                var entries = QuerySQLiteHistoryWithTimestamps(tempDbPath);
+
+                Assert.Equal(3, entries.Length);
+
+                // Find timestamps by command
+                var firstTs = entries.First(e => e.CommandLine == "first").LastExecuted;
+                var secondTs = entries.First(e => e.CommandLine == "second").LastExecuted;
+                var thirdTs = entries.First(e => e.CommandLine == "third").LastExecuted;
+
+                // Chronological order: oldest text line must have earliest timestamp
+                Assert.True(firstTs < secondTs,
+                    $"'first' timestamp ({firstTs}) should be before 'second' ({secondTs})");
+                Assert.True(secondTs < thirdTs,
+                    $"'second' timestamp ({secondTs}) should be before 'third' ({thirdTs})");
+
+                // All timestamps must be older than "now"
+                Assert.True(thirdTs < nowUnix,
+                    $"Newest migrated timestamp ({thirdTs}) should be older than now ({nowUnix})");
+            }
+            finally
+            {
+                options.HistorySavePathSQLite = originalHistorySavePathSQLite;
+                options.HistorySavePathText = originalHistorySavePathText;
+                options.HistorySaveStyle = originalHistorySaveStyle;
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+                try { if (File.Exists(tempTxtPath)) File.Delete(tempTxtPath); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// After migrating text history to SQLite, Up arrow should show the newest
+        /// text line first (reverse chronological order).
+        /// </summary>
+        [SkippableFact]
+        public void SQLiteHistory_UpArrowShowsNewestFirstAfterMigration()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var options = PSConsoleReadLine.GetOptions();
+            var originalHistorySavePathText = options.HistorySavePathText;
+            var originalHistorySavePathSQLite = options.HistorySavePathSQLite;
+            var originalHistorySaveStyle = options.HistorySaveStyle;
+            var originalHistoryType = options.HistoryType;
+
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+            var tempTxtPath = Path.ChangeExtension(tempDbPath, ".txt");
+
+            try
+            {
+                // Create text history: "first" is oldest, "third" is newest
+                File.WriteAllLines(tempTxtPath, new[] { "first", "second", "third" });
+
+                options.HistorySavePathText = tempTxtPath;
+                options.HistorySavePathSQLite = tempDbPath;
+
+                var setOptions = new SetPSReadLineOption
+                {
+                    HistoryType = HistoryType.SQLite,
+                    HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+                };
+                PSConsoleReadLine.SetOptions(setOptions);
+
+                // Up arrow should recall newest first: third, second, first
+                Test("", Keys(
+                    _.UpArrow, CheckThat(() => AssertLineIs("third")),
+                    _.UpArrow, CheckThat(() => AssertLineIs("second")),
+                    _.UpArrow, CheckThat(() => AssertLineIs("first")),
+                    _.DownArrow, _.DownArrow, _.DownArrow));
+            }
+            finally
+            {
+                options.HistorySavePathSQLite = originalHistorySavePathSQLite;
+                options.HistorySavePathText = originalHistorySavePathText;
+                options.HistorySaveStyle = originalHistorySaveStyle;
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+                try { if (File.Exists(tempTxtPath)) File.Delete(tempTxtPath); } catch { }
+            }
+        }
+
+        // =====================================================================
+        // _saved Flag Tests (Bug Fix)
+        // =====================================================================
+
+        /// <summary>
+        /// Items loaded from SQLite must have _saved=true so that IncrementalHistoryWrite
+        /// doesn't re-write them with fresh UtcNow timestamps.
+        /// Bug: Without _saved=true, the next IncrementalHistoryWrite re-wrote all loaded
+        /// items, overwriting LastExecuted with UtcNow and incrementing ExecutionCount.
+        /// </summary>
+        [SkippableFact]
+        public void SQLiteHistory_LoadedItemsNotRewrittenByIncrementalWrite()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var options = PSConsoleReadLine.GetOptions();
+            var originalHistorySavePathText = options.HistorySavePathText;
+            var originalHistorySavePathSQLite = options.HistorySavePathSQLite;
+            var originalHistorySaveStyle = options.HistorySaveStyle;
+            var originalHistoryType = options.HistoryType;
+
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+            var tempTxtPath = Path.ChangeExtension(tempDbPath, ".txt");
+
+            try
+            {
+                // Create text history and migrate to SQLite
+                File.WriteAllLines(tempTxtPath, new[] { "old-cmd1", "old-cmd2" });
+
+                options.HistorySavePathText = tempTxtPath;
+                options.HistorySavePathSQLite = tempDbPath;
+
+                var setOptions = new SetPSReadLineOption
+                {
+                    HistoryType = HistoryType.SQLite,
+                    HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+                };
+                PSConsoleReadLine.SetOptions(setOptions);
+
+                // Record execution counts after migration
+                var beforeEntries = QuerySQLiteHistoryWithTimestamps(tempDbPath);
+                var cmd1CountBefore = beforeEntries.First(e => e.CommandLine == "old-cmd1").ExecutionCount;
+                var cmd2CountBefore = beforeEntries.First(e => e.CommandLine == "old-cmd2").ExecutionCount;
+
+                // Run a NEW command — this triggers IncrementalHistoryWrite.
+                // If loaded items lacked _saved=true, they'd all be re-written here.
+                Test("new-cmd", Keys("new-cmd"));
+
+                // Verify old commands' ExecutionCount hasn't been incremented
+                var afterEntries = QuerySQLiteHistoryWithTimestamps(tempDbPath);
+                var cmd1CountAfter = afterEntries.First(e => e.CommandLine == "old-cmd1").ExecutionCount;
+                var cmd2CountAfter = afterEntries.First(e => e.CommandLine == "old-cmd2").ExecutionCount;
+
+                Assert.Equal(cmd1CountBefore, cmd1CountAfter);
+                Assert.Equal(cmd2CountBefore, cmd2CountAfter);
+
+                // Also verify the new command was written
+                Assert.Contains(afterEntries, e => e.CommandLine == "new-cmd");
+            }
+            finally
+            {
+                options.HistorySavePathSQLite = originalHistorySavePathSQLite;
+                options.HistorySavePathText = originalHistorySavePathText;
+                options.HistorySaveStyle = originalHistorySaveStyle;
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+                try { if (File.Exists(tempTxtPath)) File.Delete(tempTxtPath); } catch { }
+            }
+        }
+
+        /// <summary>
+        /// After writing commands to SQLite and reloading, the new command typed after
+        /// reload should appear newest in Up-arrow recall, not interleaved with old ones.
+        /// </summary>
+        [SkippableFact]
+        public void SQLiteHistory_MigratedTextHistoryOlderThanNewSQLiteEntries()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var options = PSConsoleReadLine.GetOptions();
+            var originalHistorySavePathText = options.HistorySavePathText;
+            var originalHistorySavePathSQLite = options.HistorySavePathSQLite;
+            var originalHistorySaveStyle = options.HistorySaveStyle;
+            var originalHistoryType = options.HistoryType;
+
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+            var tempTxtPath = Path.ChangeExtension(tempDbPath, ".txt");
+
+            try
+            {
+                // Migrate text history
+                File.WriteAllLines(tempTxtPath, new[] { "old-a", "old-b" });
+
+                options.HistorySavePathText = tempTxtPath;
+                options.HistorySavePathSQLite = tempDbPath;
+
+                var setOptions = new SetPSReadLineOption
+                {
+                    HistoryType = HistoryType.SQLite,
+                    HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+                };
+                PSConsoleReadLine.SetOptions(setOptions);
+
+                // Type a new command after migration
+                Test("new-x", Keys("new-x"));
+
+                // Up arrow should show new-x first (newest), then old-b, then old-a
+                Test("", Keys(
+                    _.UpArrow, CheckThat(() => AssertLineIs("new-x")),
+                    _.UpArrow, CheckThat(() => AssertLineIs("old-b")),
+                    _.UpArrow, CheckThat(() => AssertLineIs("old-a")),
+                    _.DownArrow, _.DownArrow, _.DownArrow));
+            }
+            finally
+            {
+                options.HistorySavePathSQLite = originalHistorySavePathSQLite;
+                options.HistorySavePathText = originalHistorySavePathText;
+                options.HistorySaveStyle = originalHistorySaveStyle;
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+                try { if (File.Exists(tempTxtPath)) File.Delete(tempTxtPath); } catch { }
+            }
         }
 
         // =====================================================================

--- a/test/SQLiteHistoryTest.cs
+++ b/test/SQLiteHistoryTest.cs
@@ -1,0 +1,449 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Data.Sqlite;
+using Microsoft.PowerShell;
+using Xunit;
+
+namespace Test
+{
+    public partial class ReadLine
+    {
+        /// <summary>
+        /// Helper to configure SQLite history mode for tests.
+        /// Sets up a temp .db file, switches HistoryType to SQLite with SaveIncrementally,
+        /// and returns a disposable that restores original settings and cleans up.
+        /// </summary>
+        private SQLiteTestContext SetupSQLiteHistory()
+        {
+            var options = PSConsoleReadLine.GetOptions();
+            var ctx = new SQLiteTestContext
+            {
+                OriginalHistorySavePath = options.HistorySavePath,
+                OriginalSqliteHistorySavePath = options.SqliteHistorySavePath,
+                OriginalHistorySaveStyle = options.HistorySaveStyle,
+                OriginalHistoryType = options.HistoryType,
+                TempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db"),
+            };
+
+            // Point SqliteHistorySavePath to our temp DB before switching mode,
+            // because SetOptionsInternal reads SqliteHistorySavePath when HistoryType is set to SQLite.
+            options.SqliteHistorySavePath = ctx.TempDbPath;
+
+            // Switch to SQLite mode — this creates the DB and clears in-memory history.
+            var setOptions = new SetPSReadLineOption
+            {
+                HistoryType = HistoryType.SQLite,
+                HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+            };
+            PSConsoleReadLine.SetOptions(setOptions);
+
+            return ctx;
+        }
+
+        /// <summary>
+        /// Holds the original settings so they can be restored after a SQLite test.
+        /// </summary>
+        private class SQLiteTestContext : IDisposable
+        {
+            public string OriginalHistorySavePath;
+            public string OriginalSqliteHistorySavePath;
+            public HistorySaveStyle OriginalHistorySaveStyle;
+            public HistoryType OriginalHistoryType;
+            public string TempDbPath;
+
+            public void Dispose()
+            {
+                var options = PSConsoleReadLine.GetOptions();
+
+                // Restore original settings
+                options.SqliteHistorySavePath = OriginalSqliteHistorySavePath;
+                options.HistorySavePath = OriginalHistorySavePath;
+                options.HistorySaveStyle = OriginalHistorySaveStyle;
+                options.HistoryType = OriginalHistoryType;
+
+                PSConsoleReadLine.ClearHistory();
+
+                // Clean up temp DB file
+                try { if (File.Exists(TempDbPath)) File.Delete(TempDbPath); }
+                catch { /* best effort */ }
+            }
+        }
+
+        /// <summary>
+        /// Helper to count rows in a SQLite table.
+        /// </summary>
+        private long CountSQLiteRows(string dbPath, string tableName)
+        {
+            var connectionString = new SqliteConnectionStringBuilder($"Data Source={dbPath}")
+            {
+                Mode = SqliteOpenMode.ReadOnly
+            }.ToString();
+
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = $"SELECT COUNT(*) FROM {tableName}";
+            return (long)cmd.ExecuteScalar();
+        }
+
+        /// <summary>
+        /// Helper to query command lines from the SQLite database.
+        /// </summary>
+        private string[] QuerySQLiteCommandLines(string dbPath)
+        {
+            var connectionString = new SqliteConnectionStringBuilder($"Data Source={dbPath}")
+            {
+                Mode = SqliteOpenMode.ReadOnly
+            }.ToString();
+
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT CommandLine FROM HistoryView ORDER BY LastExecuted ASC";
+            using var reader = cmd.ExecuteReader();
+            var results = new System.Collections.Generic.List<string>();
+            while (reader.Read())
+            {
+                results.Add(reader.GetString(0));
+            }
+            return results.ToArray();
+        }
+
+        // =====================================================================
+        // SQLite Database Persistence Tests
+        // =====================================================================
+
+        [SkippableFact]
+        public void SQLiteHistory_WritesToDatabase()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var ctx = SetupSQLiteHistory();
+
+            // Run commands that get saved to history
+            Test("echo hello", Keys("echo hello"));
+            Test("dir", Keys("dir"));
+            Test("ps", Keys("ps"));
+
+            // Verify the database has the expected commands
+            var commands = QuerySQLiteCommandLines(ctx.TempDbPath);
+            Assert.Contains("echo hello", commands);
+            Assert.Contains("dir", commands);
+            Assert.Contains("ps", commands);
+        }
+
+        [SkippableFact]
+        public void SQLiteHistory_DatabaseSchemaCreated()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var ctx = SetupSQLiteHistory();
+
+            // Verify the database file was created
+            Assert.True(File.Exists(ctx.TempDbPath), "SQLite database file should exist");
+
+            // Verify the schema by checking tables exist
+            var connectionString = new SqliteConnectionStringBuilder($"Data Source={ctx.TempDbPath}")
+            {
+                Mode = SqliteOpenMode.ReadOnly
+            }.ToString();
+
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+
+            // Check all three tables exist
+            foreach (var table in new[] { "Commands", "Locations", "ExecutionHistory" })
+            {
+                using var cmd = connection.CreateCommand();
+                cmd.CommandText = "SELECT name FROM sqlite_master WHERE type='table' AND name=@Name";
+                cmd.Parameters.AddWithValue("@Name", table);
+                Assert.NotNull(cmd.ExecuteScalar());
+            }
+
+            // Check the view exists
+            using var viewCmd = connection.CreateCommand();
+            viewCmd.CommandText = "SELECT name FROM sqlite_master WHERE type='view' AND name='HistoryView'";
+            Assert.NotNull(viewCmd.ExecuteScalar());
+        }
+
+        [SkippableFact]
+        public void SQLiteHistory_DeduplicatesCommands()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var ctx = SetupSQLiteHistory();
+
+            // Need to disable in-memory no-duplicates to ensure both reach SQLite
+            PSConsoleReadLine.SetOptions(new SetPSReadLineOption { HistoryNoDuplicates = false });
+
+            // Run the same command multiple times
+            Test("echo hello", Keys("echo hello"));
+            Test("echo hello", Keys("echo hello"));
+            Test("echo hello", Keys("echo hello"));
+
+            // The Commands table should only have one row for "echo hello"
+            long commandCount = CountSQLiteRows(ctx.TempDbPath, "Commands");
+            Assert.Equal(1, commandCount);
+
+            // But ExecutionHistory should track the execution count
+            var connectionString = new SqliteConnectionStringBuilder($"Data Source={ctx.TempDbPath}")
+            {
+                Mode = SqliteOpenMode.ReadOnly
+            }.ToString();
+
+            using var connection = new SqliteConnection(connectionString);
+            connection.Open();
+            using var cmd = connection.CreateCommand();
+            cmd.CommandText = "SELECT ExecutionCount FROM ExecutionHistory";
+            var executionCount = Convert.ToInt64(cmd.ExecuteScalar());
+            Assert.True(executionCount >= 3, $"ExecutionCount should be >= 3, was {executionCount}");
+        }
+
+        [SkippableFact]
+        public void SQLiteHistory_StoresLocation()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var ctx = SetupSQLiteHistory();
+
+            // Run a command - location defaults to "Unknown" in test harness
+            // because _engineIntrinsics is null
+            Test("echo hello", Keys("echo hello"));
+
+            // Verify location was stored
+            long locationCount = CountSQLiteRows(ctx.TempDbPath, "Locations");
+            Assert.True(locationCount >= 1, "Should have at least one location");
+        }
+
+        // =====================================================================
+        // SQLite Migration Tests
+        // =====================================================================
+
+        [SkippableFact]
+        public void SQLiteHistory_MigratesFromTextFile()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var options = PSConsoleReadLine.GetOptions();
+            var originalHistorySavePath = options.HistorySavePath;
+            var originalSqliteHistorySavePath = options.SqliteHistorySavePath;
+            var originalHistorySaveStyle = options.HistorySaveStyle;
+            var originalHistoryType = options.HistoryType;
+
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+            var tempTxtPath = Path.ChangeExtension(tempDbPath, ".txt");
+
+            try
+            {
+                // Create a text history file with known content
+                File.WriteAllLines(tempTxtPath, new[]
+                {
+                    "get-process",
+                    "cd /tmp",
+                    "echo hello"
+                });
+
+                // Set up SQLite mode pointing at the temp path
+                options.SqliteHistorySavePath = tempDbPath;
+
+                var setOptions = new SetPSReadLineOption
+                {
+                    HistoryType = HistoryType.SQLite,
+                    HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+                };
+                PSConsoleReadLine.SetOptions(setOptions);
+
+                // The migration should have imported the text history
+                long commandCount = CountSQLiteRows(tempDbPath, "Commands");
+                Assert.Equal(3, commandCount);
+
+                // Verify the specific commands were migrated
+                var commands = QuerySQLiteCommandLines(tempDbPath);
+                Assert.Contains("get-process", commands);
+                Assert.Contains("cd /tmp", commands);
+                Assert.Contains("echo hello", commands);
+            }
+            finally
+            {
+                // Restore original settings
+                options.SqliteHistorySavePath = originalSqliteHistorySavePath;
+                options.HistorySavePath = originalHistorySavePath;
+                options.HistorySaveStyle = originalHistorySaveStyle;
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+                try { if (File.Exists(tempTxtPath)) File.Delete(tempTxtPath); } catch { }
+            }
+        }
+
+        [SkippableFact]
+        public void SQLiteHistory_MigrationSkippedWhenNoTextFile()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var options = PSConsoleReadLine.GetOptions();
+            var originalHistorySavePath = options.HistorySavePath;
+            var originalSqliteHistorySavePath = options.SqliteHistorySavePath;
+            var originalHistorySaveStyle = options.HistorySaveStyle;
+            var originalHistoryType = options.HistoryType;
+
+            // Use a temp path where no .txt file exists
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+
+            try
+            {
+                options.SqliteHistorySavePath = tempDbPath;
+
+                var setOptions = new SetPSReadLineOption
+                {
+                    HistoryType = HistoryType.SQLite,
+                    HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+                };
+
+                // Should not throw even without a text file
+                Exception ex = Record.Exception(() => PSConsoleReadLine.SetOptions(setOptions));
+                Assert.Null(ex);
+
+                // Database should exist but with no command rows
+                Assert.True(File.Exists(tempDbPath));
+                long commandCount = CountSQLiteRows(tempDbPath, "Commands");
+                Assert.Equal(0, commandCount);
+            }
+            finally
+            {
+                options.SqliteHistorySavePath = originalSqliteHistorySavePath;
+                options.HistorySavePath = originalHistorySavePath;
+                options.HistorySaveStyle = originalHistorySaveStyle;
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+            }
+        }
+
+        [SkippableFact]
+        public void SQLiteHistory_MigrationOnlyHappensOnce()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var options = PSConsoleReadLine.GetOptions();
+            var originalHistorySavePath = options.HistorySavePath;
+            var originalSqliteHistorySavePath = options.SqliteHistorySavePath;
+            var originalHistorySaveStyle = options.HistorySaveStyle;
+            var originalHistoryType = options.HistoryType;
+
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+            var tempTxtPath = Path.ChangeExtension(tempDbPath, ".txt");
+
+            try
+            {
+                // Create a text history file
+                File.WriteAllLines(tempTxtPath, new[] { "cmd1", "cmd2" });
+
+                // First switch to SQLite - should migrate
+                options.SqliteHistorySavePath = tempDbPath;
+                var setOptions = new SetPSReadLineOption
+                {
+                    HistoryType = HistoryType.SQLite,
+                    HistorySaveStyle = HistorySaveStyle.SaveIncrementally,
+                };
+                PSConsoleReadLine.SetOptions(setOptions);
+
+                long countAfterFirstMigration = CountSQLiteRows(tempDbPath, "Commands");
+                Assert.Equal(2, countAfterFirstMigration);
+
+                // Add another command to the text file (simulating continued text use)
+                File.AppendAllText(tempTxtPath, "cmd3\n");
+
+                // Switch back to Text, then back to SQLite again
+                // Since the DB already exists, migration should NOT run again
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                PSConsoleReadLine.SetOptions(setOptions);
+
+                long countAfterSecondSwitch = CountSQLiteRows(tempDbPath, "Commands");
+                // Should still be 2, not 3 — the migration didn't re-run
+                Assert.Equal(2, countAfterSecondSwitch);
+            }
+            finally
+            {
+                options.SqliteHistorySavePath = originalSqliteHistorySavePath;
+                options.HistorySavePath = originalHistorySavePath;
+                options.HistorySaveStyle = originalHistorySaveStyle;
+                options.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+                try { if (File.Exists(tempTxtPath)) File.Delete(tempTxtPath); } catch { }
+            }
+        }
+
+        // =====================================================================
+        // SQLite Location-Aware History Recall (new feature)
+        // =====================================================================
+
+        [SkippableFact]
+        public void SQLiteHistory_LocationIsStoredPerCommand()
+        {
+            TestSetup(KeyMode.Cmd);
+            using var ctx = SetupSQLiteHistory();
+
+            // Run commands — in test harness, Location defaults to "Unknown"
+            Test("echo hello", Keys("echo hello"));
+            Test("dir", Keys("dir"));
+
+            // Verify that different commands share the same location ("Unknown")
+            long locationCount = CountSQLiteRows(ctx.TempDbPath, "Locations");
+            Assert.Equal(1, locationCount);
+
+            // Verify both commands appear in ExecutionHistory
+            long ehCount = CountSQLiteRows(ctx.TempDbPath, "ExecutionHistory");
+            Assert.Equal(2, ehCount);
+        }
+
+        // =====================================================================
+        // Type Acceptance Test
+        // =====================================================================
+
+        [SkippableFact]
+        public void SQLiteHistory_SetPSReadLineOptionAcceptsSQLite()
+        {
+            TestSetup(KeyMode.Cmd);
+
+            var psrlOptions = PSConsoleReadLine.GetOptions();
+            var originalSqlitePath = psrlOptions.SqliteHistorySavePath;
+            var originalHistorySavePath = psrlOptions.HistorySavePath;
+            var originalHistoryType = psrlOptions.HistoryType;
+            var tempDbPath = Path.Combine(Path.GetTempPath(), $"PSReadLineTest_{Guid.NewGuid():N}.db");
+
+            try
+            {
+                psrlOptions.SqliteHistorySavePath = tempDbPath;
+
+                var optionsType = typeof(SetPSReadLineOption);
+                var historyTypeProperty = optionsType.GetProperty("HistoryType");
+                Assert.NotNull(historyTypeProperty);
+
+                var options = new SetPSReadLineOption();
+                historyTypeProperty.SetValue(options, HistoryType.SQLite);
+
+                Exception ex = Record.Exception(() => PSConsoleReadLine.SetOptions(options));
+                Assert.Null(ex);
+
+                Assert.Equal(HistoryType.SQLite, historyTypeProperty.GetValue(options));
+
+                // Restore to default
+                historyTypeProperty.SetValue(options, HistoryType.Text);
+                PSConsoleReadLine.SetOptions(options);
+            }
+            finally
+            {
+                psrlOptions.SqliteHistorySavePath = originalSqlitePath;
+                psrlOptions.HistorySavePath = originalHistorySavePath;
+                psrlOptions.HistoryType = originalHistoryType;
+                PSConsoleReadLine.ClearHistory();
+                try { if (File.Exists(tempDbPath)) File.Delete(tempDbPath); } catch { }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds support for storing command history in a SQLite database as an alternative to the traditional text file in PSReadLine. It introduces new options for configuring history storage, updates the build and packaging process to include required SQLite dependencies, and makes the history system more flexible and extensible. The changes ensure that users can choose between text and SQLite-based history, and that the correct files are managed and loaded depending on the selected mode.

Key changes include:

**SQLite History Support and Configuration:**

* Introduced a new `HistoryType` enum with options for `Text` and `SQLite`, and updated the `PSConsoleReadLineOptions` class to support selecting the history type (`HistoryType` property, defaulting to text). The active history save path is now determined by the selected type, with separate properties for text and SQLite paths (`HistorySavePathText`, `HistorySavePathSQLite`). [[1]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfL65-R72) [[2]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfR117-R122) [[3]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfR214) [[4]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfL228-R255) [[5]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfL243-R273) [[6]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfL256-R301) [[7]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfR370) [[8]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfL372-R423) [[9]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfR707-R720) [[10]](diffhunk://#diff-e6548f7558f27938760b986bc9b59e883d30cae7f333a5ecf21adfb1dbfbd5cfL788-R871)

* Updated `SetPSReadLineOption` and internal logic to handle switching between history types, including initializing the SQLite database, migrating text history, and reloading history as needed. [[1]](diffhunk://#diff-6a6caa16304a1b46e6323d1d18264aa1e7cee998f535c02d05d1fc50f0e82a41R29-R49) [[2]](diffhunk://#diff-6a6caa16304a1b46e6323d1d18264aa1e7cee998f535c02d05d1fc50f0e82a41L125-R178)

* Adjusted history reading and writing logic to respect the selected history type, including passing the current location for SQLite history entries and only reading the text history file if in text mode. [[1]](diffhunk://#diff-e6037c048023d38e5cc2d2a6ccbe669010793d55f5d34bfc631c208a43589d89R570-R578) [[2]](diffhunk://#diff-e6037c048023d38e5cc2d2a6ccbe669010793d55f5d34bfc631c208a43589d89L918-R926) [[3]](diffhunk://#diff-33fdaa3863da6a4ba3476216979e2df89e46e31558d8a3dc4aabb48134447aaeR60-R64)

**Build and Packaging Updates:**

* Modified the build process to restructure native SQLite DLLs into a layout compatible with PowerShell's native DLL handler, and ensured all necessary managed and native SQLite dependencies are copied to the output and layout directories. [[1]](diffhunk://#diff-cf52a72665faf1250da83a9745360bf052fadf8f4a395bf0557d6f1b6ffcec18R60-R76) [[2]](diffhunk://#diff-cf52a72665faf1250da83a9745360bf052fadf8f4a395bf0557d6f1b6ffcec18R130-R154)

* Updated project file to include `Microsoft.Data.Sqlite` and `SQLitePCLRaw.bundle_e_sqlite3` as dependencies, and enabled `CopyLocalLockFileAssemblies` for proper DLL deployment.

* Changed the NuGet configuration to use the official `nuget.org` feed.

**User Interface and Testing:**

* Updated the format file to display the new history-related properties (`HistoryType`, `HistorySavePathText`, `HistorySavePathSQLite`) in the output.

* Adjusted tests to use the new property names for history file paths. [[1]](diffhunk://#diff-2b3d36837b2b1c288c4ea799051ba79918f11da30cc425da89da544d3ebf6468L43-R50) [[2]](diffhunk://#diff-2b3d36837b2b1c288c4ea799051ba79918f11da30cc425da89da544d3ebf6468L101-R102) [[3]](diffhunk://#diff-2b3d36837b2b1c288c4ea799051ba79918f11da30cc425da89da544d3ebf6468L138-R139)

## PR Context
This feature is discussed in issues: #3673 #1886 

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [x] Doc Issue filed: https://github.com/MicrosoftDocs/PowerShell-Docs/issues/12811

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4833)