### PR TITLE
ViGotoBrace: jump when current char is not brace

### DIFF
--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -254,7 +254,21 @@ namespace Microsoft.PowerShell
                 case ')':
                     return ViFindBackward(i, '(', withoutPassing: ')');
                 default:
-                    return i;
+                    int a = ViFindForward(i, '{', withoutPassing: '}') is var x and > 0 ? x : int.MaxValue;
+                    int b = ViFindForward(i, '[', withoutPassing: ']') is var y and > 0 ? y : int.MaxValue;
+                    int c = ViFindForward(i, '(', withoutPassing: ')') is var z and > 0 ? z : int.MaxValue;
+                    int closest = Math.Min(Math.Min(a, b), c);
+                    switch (_buffer[closest])
+                    {
+                        case '{':
+                            return ViFindForward(closest, '}', withoutPassing: '{');
+                        case ']':
+                            return ViFindForward(closest, ']', withoutPassing: '[');
+                        case ')':
+                            return ViFindForward(closest, ')', withoutPassing: '(');
+                        default:
+                            return i;
+                    }
             }
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`ViGotoBrace` should behave as vi/vim that, it searches to right pair of next brace even when current char is not a brace.

Looks like this:

![foo](https://github.com/user-attachments/assets/00304e6d-1580-431c-9841-3ebdd4a54ca4)


<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4857)