### PR TITLE
Fix that ViFindBrace doesn't search for brace when current char is not a brace

### DIFF
--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -254,7 +254,28 @@ namespace Microsoft.PowerShell
                 case ')':
                     return ViFindBackward(i, '(', withoutPassing: ')');
                 default:
-                    return i;
+                    ReadOnlySpan<char> parenthese = stackalloc char[] { '{', '}', '(', ')', '[', ']' };
+                    int nextParen = i;
+                    // find next of any kind of paren
+                    for (; nextParen < _buffer.Length; nextParen++)
+                        for (int idx = 0; idx < parenthese.Length; idx++)
+                            if (parenthese[idx] == _buffer[nextParen]) goto Outer;
+
+                Outer:
+                    int match = _buffer[nextParen] switch
+                    {
+                        // if next is opening, find forward
+                        '{' => ViFindForward(nextParen, '}', withoutPassing: '{'),
+                        '[' => ViFindForward(nextParen, ']', withoutPassing: '['),
+                        '(' => ViFindForward(nextParen, ')', withoutPassing: '('),
+                        // if next is closing, find backward
+                        '}' => ViFindBackward(nextParen, '{', withoutPassing: '}'),
+                        ']' => ViFindBackward(nextParen, '[', withoutPassing: ']'),
+                        ')' => ViFindBackward(nextParen, '(', withoutPassing: ')'),
+                        _ => nextParen
+                    };
+
+                    return match == nextParen ? i : match;
             }
         }
 

--- a/PSReadLine/Movement.vi.cs
+++ b/PSReadLine/Movement.vi.cs
@@ -254,12 +254,16 @@ namespace Microsoft.PowerShell
                 case ')':
                     return ViFindBackward(i, '(', withoutPassing: ')');
                 default:
-                    ReadOnlySpan<char> parenthese = stackalloc char[] { '{', '}', '(', ')', '[', ']' };
+                    ReadOnlySpan<char> parentheses = stackalloc char[] { '{', '}', '(', ')', '[', ']' };
                     int nextParen = i;
                     // find next of any kind of paren
                     for (; nextParen < _buffer.Length; nextParen++)
-                        for (int idx = 0; idx < parenthese.Length; idx++)
-                            if (parenthese[idx] == _buffer[nextParen]) goto Outer;
+                        for (int idx = 0; idx < parentheses.Length; idx++)
+                            if (parentheses[idx] == _buffer[nextParen]) goto Outer;
+
+                    // if not found, nextParen could exceed the range
+                    if (nextParen >= _buffer.Length)
+                        return i;
 
                 Outer:
                     int match = _buffer[nextParen] switch

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -424,6 +424,11 @@ namespace Test
         [SkippableFact]
         public void ViGotoBrace()
         {
+            // NOTE: When the input has unmatched braces, in order to avoid an
+            // exception caused by AcceptLineImpl waiting for incomplete input,
+            // the test needs to end with the Vi command "ddi" and assert that
+            // the result is an empty string.
+
             TestSetup(KeyMode.Vi);
 
             Test("0[2(4{6]8)a}c", Keys(
@@ -451,25 +456,26 @@ namespace Test
                     CheckThat(() => AssertCursorLeftIs(4)),
                     _.Percent,
                     CheckThat(() => AssertCursorLeftIs(4)),
-                    "ddi"
+                    "ddi" // Unmatched brace
                     ));
             }
 
-            // tests when cursor not on any paren
+            // Tests when the cursor is not on any paren
             foreach (var (opening, closing) in new[] { ('(', ')'), ('{', '}'), ('[', ']') })
             {
-                // closing paren with backward match
+                // Closing paren with backward match
                 string input1 = $"0{opening}2{opening}4foo{closing}";
-                Test(input1, Keys(
+                Test("", Keys(
                     input1,
                     CheckThat(() => AssertCursorLeftIs(9)),
                     _.Escape, CheckThat(() => AssertCursorLeftIs(8)),
                     "0ff", CheckThat(() => AssertCursorLeftIs(5)),
                     _.Percent, CheckThat(() => AssertCursorLeftIs(3)),
-                    _.Percent, CheckThat(() => AssertCursorLeftIs(8))
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(8)),
+                    "ddi" // Unmatched closing brace
                 ));
 
-                // closing paren without backward match
+                // Closing paren without backward match
                 string input2 = $"0]2)4foo{closing}";
                 Test(input2, Keys(
                     input2,
@@ -480,7 +486,7 @@ namespace Test
                     _.Percent, CheckThat(() => AssertCursorLeftIs(5))
                 ));
 
-                // opening paren with forward match
+                // Opening paren with forward match
                 string input3 = $"0{opening}2foo6{closing}";
                 Test(input3, Keys(
                     input3,
@@ -490,15 +496,17 @@ namespace Test
                     _.Percent, CheckThat(() => AssertCursorLeftIs(1)),
                     _.Percent, CheckThat(() => AssertCursorLeftIs(7))
                 ));
-                // opening paren without forward match
+
+                // Opening paren without forward match
                 string input4 = $"0)2]4foo{opening}(";
-                Test(input4, Keys(
+                TestMustDing("", Keys(
                     input4,
                     CheckThat(() => AssertCursorLeftIs(10)),
                     _.Escape, CheckThat(() => AssertCursorLeftIs(9)),
                     "0ff", CheckThat(() => AssertCursorLeftIs(5)),
                     _.Percent, CheckThat(() => AssertCursorLeftIs(5)), // stay still
-                    _.Percent, CheckThat(() => AssertCursorLeftIs(5))
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(5)),
+                    "ddi" // Unmatched brace
                 ));
             }
 

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.Collections.Generic;
+using Xunit;
 
 namespace Test
 {
@@ -370,7 +371,7 @@ namespace Test
             TestSetup(KeyMode.Vi);
 
             TestMustDing("", Keys(
-                _.Escape, "W" 
+                _.Escape, "W"
             ));
         }
 
@@ -452,6 +453,53 @@ namespace Test
                     CheckThat(() => AssertCursorLeftIs(4)),
                     "ddi"
                     ));
+            }
+
+            // tests when cursor not on any paren
+            foreach (var (opening, closing) in new[] { ('(', ')'), ('{', '}'), ('[', ']') })
+            {
+                // closing paren with backward match
+                string input1 = $"0{opening}2{opening}4foo{closing}";
+                Test(input1, Keys(
+                    input1,
+                    CheckThat(() => AssertCursorLeftIs(9)),
+                    _.Escape, CheckThat(() => AssertCursorLeftIs(8)),
+                    "0ff", CheckThat(() => AssertCursorLeftIs(5)),
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(3)),
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(8))
+                ));
+
+                // closing paren without backward match
+                string input2 = $"0]2)4foo{closing}";
+                Test(input2, Keys(
+                    input2,
+                    CheckThat(() => AssertCursorLeftIs(9)),
+                    _.Escape, CheckThat(() => AssertCursorLeftIs(8)),
+                    "0ff", CheckThat(() => AssertCursorLeftIs(5)),
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(5)), // stay still
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(5))
+                ));
+
+                // opening paren with forward match
+                string input3 = $"0{opening}2foo6{closing}";
+                Test(input3, Keys(
+                    input3,
+                    CheckThat(() => AssertCursorLeftIs(8)),
+                    _.Escape, CheckThat(() => AssertCursorLeftIs(7)),
+                    "0ff", CheckThat(() => AssertCursorLeftIs(3)),
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(1)),
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(7))
+                ));
+                // opening paren without forward match
+                string input4 = $"0)2]4foo{opening}(";
+                Test(input4, Keys(
+                    input4,
+                    CheckThat(() => AssertCursorLeftIs(10)),
+                    _.Escape, CheckThat(() => AssertCursorLeftIs(9)),
+                    "0ff", CheckThat(() => AssertCursorLeftIs(5)),
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(5)), // stay still
+                    _.Percent, CheckThat(() => AssertCursorLeftIs(5))
+                ));
             }
 
             // <%> with empty text buffer should work fine.

--- a/test/MovementTest.VI.cs
+++ b/test/MovementTest.VI.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using Xunit;
+﻿using Xunit;
 
 namespace Test
 {
@@ -477,7 +476,7 @@ namespace Test
 
                 // Closing paren without backward match
                 string input2 = $"0]2)4foo{closing}";
-                Test(input2, Keys(
+                TestMustDing(input2, Keys(
                     input2,
                     CheckThat(() => AssertCursorLeftIs(9)),
                     _.Escape, CheckThat(() => AssertCursorLeftIs(8)),


### PR DESCRIPTION

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Vi searches right pair of first left brace, or first right brace when current char is not a brace. This pr added this functionality.

After the update, `ViGotoBrace` should work like this(of course this will also affect other methods such as `ViDeleteBrace`):
![foo](https://github.com/user-attachments/assets/6a0dc431-e4f0-4fb4-991c-9f0a446766e2)


<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4862)