### PR TITLE
Add 'ScreenReaderModeEnabled' to formatting

### DIFF
--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -145,6 +145,9 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>ShowToolTips</PropertyName>
               </ListItem>
               <ListItem>
+                <PropertyName>ScreenReaderModeEnabled</PropertyName>
+              </ListItem>
+              <ListItem>
                 <PropertyName>ViModeIndicator</PropertyName>
               </ListItem>
               <ListItem>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Add the `ScreenReaderModeEnabled` property to formatting so it's displayed in the default formatting for `Get-PSReadLineOption`.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4970)