### PR TITLE
Fix a null reference exception when showing parameter help

### DIFF
--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -67,7 +67,6 @@ namespace Microsoft.PowerShell
                     .AddParameter("Parameter", parameterName)
                     .Invoke<PSObject>()
                     .FirstOrDefault();
-
             }
             catch (Exception)
             {
@@ -194,9 +193,9 @@ namespace Microsoft.PowerShell
         {
             Collection<string> helpBlock;
 
-            if (helpContent?.Description is not string descriptionText)
+            if (helpContent.Description is not string descriptionText)
             {
-                descriptionText = helpContent?.Description?[0]?.Text;
+                descriptionText = helpContent.Description?[0]?.Text;
             }
 
             if (descriptionText is null)
@@ -209,7 +208,7 @@ namespace Microsoft.PowerShell
             }
             else
             {
-                string syntax = $"-{helpContent.name} <{helpContent.type.name}>";
+                string syntax = $"-{helpContent.name} <{helpContent.type?.name}>";
                 helpBlock = new Collection<string>
                 {
                     string.Empty,

--- a/PSReadLine/DynamicHelp.cs
+++ b/PSReadLine/DynamicHelp.cs
@@ -191,6 +191,8 @@ namespace Microsoft.PowerShell
 
         private void WriteParameterHelp(dynamic helpContent)
         {
+            System.Diagnostics.Debug.Assert(helpContent is not null);
+
             Collection<string> helpBlock;
 
             if (helpContent.Description is not string descriptionText)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #4960

The null reference is caused by the expression `helpContent.type.name` in the code. `helpContent` is a dynamic object that's guaranteed to not be `null`, and in a rare case, `helpContent.type` is null, so null reference exception gets thrown.

It's fixed by using `helpContent.type?.name`. @kborowinski kindly validated and confirmed the fix (THANK YOU!).

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/4971)