### PR TITLE
Fix BackwardKillLine length calculation for multiline input

### DIFF
--- a/PSReadLine/KillYank.cs
+++ b/PSReadLine/KillYank.cs
@@ -135,7 +135,7 @@ namespace Microsoft.PowerShell
         public static void BackwardKillLine(ConsoleKeyInfo? key = null, object arg = null)
         {
             var start = GetBeginningOfLinePos(_singleton._current);
-            _singleton.Kill(start, _singleton._current, true);
+            _singleton.Kill(start, _singleton._current - start, true);
         }
 
         /// <summary>

--- a/test/KillYankTest.cs
+++ b/test/KillYankTest.cs
@@ -119,6 +119,8 @@ namespace Test
             PSConsoleReadLine.SetKeyHandler(new[] { "Shift+Tab" }, PSConsoleReadLine.BackwardKillLine, "", "");
 
             Test("", Keys("dir", _.Shift_Tab));
+
+            Test("abc\n123", Keys("abc", _.Shift_Enter, "123", _.Shift_Tab, _.Ctrl_y));
         }
 
         [SkippableFact]


### PR DESCRIPTION
## Summary
- fix BackwardKillLine to delete only from current logical line start to cursor (length = current - start)
- add a regression test in KillYankTest.BackwardKillLine for multiline input to prevent ArgumentOutOfRangeException
- addresses issue #5101