### PR TITLE
Fix parsing hotkeys for non english chars

### DIFF
--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -250,7 +250,7 @@ namespace Microsoft.PowerShell
                     // ToUnicodeEx call which would return a layout-dependent character
                     // (e.g. Cyrillic 'с' instead of Latin 'c' on Russian layout), breaking
                     // key binding matching.
-                    if (!isDeadKey && !(c >= 1 && c <= 26))
+                    if (!isDeadKey && !(c >= '\x01' && c <= '\x1A'))
                     {
                         // A dead key could pass the above heuristic check, such as 'Shift+6' in US-INTL keyboard, which represents the
                         // diacritic '^' and generates 'D6' ConsoleKey, '\0' key char and 'Shift' modifier.

--- a/PSReadLine/Keys.cs
+++ b/PSReadLine/Keys.cs
@@ -245,7 +245,12 @@ namespace Microsoft.PowerShell
                     //   another special key, such as 'Ctrl+?' and 'Ctrl+;'.
                     isDeadKey = (c == '\0') && (consoleKey >= ConsoleKey.Oem1 && consoleKey <= ConsoleKey.Oem102) && !isCtrl;
 
-                    if (!isDeadKey)
+                    // For standard Ctrl+letter combinations (KeyChar \x01-\x1A), the mapping
+                    // to letters a-z is well-defined and layout-independent, so we skip the
+                    // ToUnicodeEx call which would return a layout-dependent character
+                    // (e.g. Cyrillic 'с' instead of Latin 'c' on Russian layout), breaking
+                    // key binding matching.
+                    if (!isDeadKey && !(c >= 1 && c <= 26))
                     {
                         // A dead key could pass the above heuristic check, such as 'Shift+6' in US-INTL keyboard, which represents the
                         // diacritic '^' and generates 'D6' ConsoleKey, '\0' key char and 'Shift' modifier.


### PR DESCRIPTION
This fixes an issue related to incorrect key handling in non-English keyboard layouts (in my case, the Russian CTRL + C shortcut).
I've had this problem for a long time and no one has fixed it yet, but with the help of AI, I discovered that the issue stems from incorrect handling of the Cyrillic alphabet.
Please test this patch, because I don’t know if it might affect something else and cause errors.

This fixes https://github.com/PowerShell/PSReadLine/issues/1393 and https://github.com/PowerShell/PSReadLine/issues/2865

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/5122)