### PR TITLE
feat(prediction): support dynamic list height and remove history caps

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -113,6 +113,21 @@ namespace Microsoft.PowerShell
         public const int DefaultMaximumHistoryCount = 4096;
 
         /// <summary>
+        /// The number of lines in prediction list;
+        /// </summary>
+        public const int DefaultPredictionListCount = 50;
+
+        /// <summary>
+        /// The number of lines in history prediction list;
+        /// </summary>
+        public const int DefaultPredictionHistoryCount = 10;
+
+        /// <summary>
+        /// The number of lines to show from prediction list;
+        /// </summary>
+        public const int DefaultPredictionViewHeight = 10;
+
+        /// <summary>
         /// The maximum number of items to store in the kill ring.
         /// </summary>
         public const int DefaultMaximumKillRingCount = 10;
@@ -202,6 +217,9 @@ namespace Microsoft.PowerShell
             ContinuationPromptColor = Console.ForegroundColor;
             ExtraPromptLineCount = DefaultExtraPromptLineCount;
             AddToHistoryHandler = DefaultAddToHistoryHandler;
+            PredictionListCount = DefaultPredictionListCount;
+            PredictionHistoryCount = DefaultPredictionHistoryCount;
+            PredictionViewHeight = DefaultPredictionViewHeight;
             HistoryNoDuplicates = DefaultHistoryNoDuplicates;
             MaximumKillRingCount = DefaultMaximumKillRingCount;
             HistorySearchCursorMovesToEnd = DefaultHistorySearchCursorMovesToEnd;
@@ -342,6 +360,9 @@ namespace Microsoft.PowerShell
 
         public int MaximumHistoryCount { get; set; }
         public int MaximumKillRingCount { get; set; }
+        public int PredictionListCount { get; set; }
+        public int PredictionHistoryCount { get; set; }
+        public int PredictionViewHeight { get; set; }
         public bool HistorySearchCursorMovesToEnd { get; set; }
         public bool ShowToolTips { get; set; }
         public int DingTone { get; set; }
@@ -654,6 +675,33 @@ namespace Microsoft.PowerShell
         [Parameter]
         [AllowEmptyString]
         public string ContinuationPrompt { get; set; }
+
+        [Parameter]
+        [ValidateRange(1, int.MaxValue)]
+        public int PredictionListCount
+        {
+            get => _predictionListCount.GetValueOrDefault();
+            set => _predictionListCount = value;
+        }
+        internal int? _predictionListCount;
+
+        [Parameter]
+        [ValidateRange(1, int.MaxValue)]
+        public int PredictionHistoryCount
+        {
+            get => _predictionHistoryCount.GetValueOrDefault();
+            set => _predictionHistoryCount = value;
+        }
+        internal int? _predictionHistoryCount;
+
+        [Parameter]
+        [ValidateRange(1, int.MaxValue)]
+        public int PredictionViewHeight
+        {
+            get => _predictionViewHeight.GetValueOrDefault();
+            set => _predictionViewHeight = value;
+        }
+        internal int? _predictionViewHeight;
 
         [Parameter]
         public SwitchParameter HistoryNoDuplicates

--- a/PSReadLine/Options.cs
+++ b/PSReadLine/Options.cs
@@ -26,6 +26,18 @@ namespace Microsoft.PowerShell
             {
                 Options.ContinuationPrompt = options.ContinuationPrompt;
             }
+            if (options._predictionListCount.HasValue)
+            {
+                Options.PredictionListCount = options.PredictionListCount;
+            }
+            if (options._predictionHistoryCount.HasValue)
+            {
+                Options.PredictionHistoryCount = options.PredictionHistoryCount;
+            }
+            if (options._predictionViewHeight.HasValue)
+            {
+                Options.PredictionViewHeight = options.PredictionViewHeight;
+            }
             if (options._historyNoDuplicates.HasValue)
             {
                 Options.HistoryNoDuplicates = options.HistoryNoDuplicates;

--- a/PSReadLine/PSReadLine.format.ps1xml
+++ b/PSReadLine/PSReadLine.format.ps1xml
@@ -112,6 +112,9 @@ $d = [Microsoft.PowerShell.KeyHandler]::GetGroupingDescription($_.Group)
                 <PropertyName>MaximumHistoryCount</PropertyName>
               </ListItem>
               <ListItem>
+                <PropertyName>PredictionViewHeight</PropertyName>
+              </ListItem>
+              <ListItem>
                 <PropertyName>ContinuationPrompt</PropertyName>
               </ListItem>
               <ListItem>

--- a/PSReadLine/Prediction.Views.cs
+++ b/PSReadLine/Prediction.Views.cs
@@ -208,9 +208,21 @@ namespace Microsoft.PowerShell
         /// </summary>
         private class PredictionListView : PredictionViewBase
         {
-            // Item count constants.
-            internal const int ListMaxCount = 50;
-            internal const int HistoryMaxCount = 10;
+            // Physical limit: What can actually fit on the screen?
+            // We use -2 for the cursor line and the "jitter buffer."
+            private int PhysicalMax => Math.Max(1, _singleton._console.BufferHeight - 2);
+
+            // Visible View: The smaller of (User Request) and (Physical Space)
+            internal int PredictionViewHeight => Math.Min(_singleton._options.PredictionViewHeight, PhysicalMax);
+
+            // Global Ceiling: Remains the total scrollable capacity
+            internal int ListMaxCount => _singleton._options.PredictionListCount;
+
+            // History Fetch: At least enough to fill the view, up to the total ListCount
+            internal int HistoryMaxCount => Math.Min(
+                Math.Max(_singleton._options.PredictionHistoryCount, PredictionViewHeight),
+                ListMaxCount
+            );
 
             // List view constants.
             internal const int ListViewMaxHeight = 10;
@@ -327,21 +339,31 @@ namespace Microsoft.PowerShell
             internal override bool HasActiveSuggestion => _listItems != null;
 
             /// <summary>
-            /// Calculate the max width and height of the list view based on the current terminal size.
+            /// Calculate the max width and height of the list view based on option value.
             /// </summary>
             private (int, int, int, bool) RefreshMaxViewSize()
             {
                 var console = _singleton._console;
                 int maxListWidth = Math.Min(console.BufferWidth, ListViewMaxWidth);
 
-                (int maxListHeight, int maxTooltipHeigth, bool moreCheck) = console.BufferHeight switch
-                {
-                    > ListViewMaxHeight * 2 => (ListViewMaxHeight, TooltipMaxHeight, false),
-                    > ListViewMaxHeight => (ListViewMaxHeight / 2, TooltipMaxHeight / 2, false),
-                    _ => (ListViewMaxHeight / 3, TooltipMaxHeight / 3, true)
-                };
+                if (HistoryMaxCount == 10) {
+                    // Don't change default behavior
+                    (int maxListHeight, int maxTooltipHeigth, bool moreCheck) = console.BufferHeight switch
+                    {
+                        > ListViewMaxHeight * 2 => (ListViewMaxHeight, TooltipMaxHeight, false),
+                        > ListViewMaxHeight => (ListViewMaxHeight / 2, TooltipMaxHeight / 2, false),
+                        _ => (ListViewMaxHeight / 3, TooltipMaxHeight / 3, true)
+                    };
 
-                return (maxListWidth, maxListHeight, maxTooltipHeigth, moreCheck);
+                    return (maxListWidth, maxListHeight, maxTooltipHeigth, moreCheck);
+                } else {
+                    int maxListHeight = HistoryMaxCount;
+                    int maxTooltipHeigth = TooltipMaxHeight;
+
+                    bool moreCheck = console.BufferHeight < maxListHeight + 2;
+
+                    return (maxListWidth, maxListHeight, maxTooltipHeigth, moreCheck);
+                }
             }
 
             /// <summary>
@@ -444,7 +466,7 @@ namespace Microsoft.PowerShell
                         _cacheList2 ??= new List<int>(); // This list holds the final number of suggestions that will be rendered for each of the predictors.
 
                         int pCount = 0;
-                        int hCount = Math.Min(3, _listItems.Count);
+                        int hCount = Math.Min(HistoryMaxCount, _listItems.Count);
                         int remRows = ListMaxCount - hCount;
 
                         // Calculate the number of plugins that we need to handle,


### PR DESCRIPTION
Replace hardcoded prediction list limits with user-configurable sizing.

Summary:
- Remove the fixed 10-line cap and legacy auto-adjustment logic
- Prediction list height and capacity now scale based on user settings
- History suggestions are no longer artificially capped when plugins are active

Key changes:
- Convert ListMaxCount and HistoryMaxCount into dynamic properties on PredictionListView
- Introduce layout constraints:
  - PhysicalMax: based on console buffer height (-2 for jitter protection)
  - PredictionViewHeight: limited by screen space and list capacity
  - HistoryMaxCount: adjusted to fill the visible view
- Remove history cap in AggregateSuggestions (previously limited to 3)

Configuration:
Add new PSConsoleReadLineOptions properties:
- PredictionViewHeight: visible list height
- PredictionListCount: total scrollable items
- PredictionHistoryCount: history fetch limit

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/5135)