### PR TITLE
Fix note formatting in README.md with blockquotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ If you only want to get the latest stable version, run:
 Install-Module PSReadLine -Repository PSGallery -Scope CurrentUser -Force
 ```
 
->[!NOTE] Prerelease versions will have newer features and bug fixes, but may also introduce new issues.
+> [!NOTE]
+>
+> Prerelease versions will have newer features and bug fixes, but may also introduce new issues.
 
 ## Usage
 


### PR DESCRIPTION
GitHub Markdown now support an option to highlight a "Note" and "Warning" using blockquotes

<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- Fix the syntax of README.md to support the new interface, to highlight notes with blockquotes: https://github.com/orgs/community/discussions/16925

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [x] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [x] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/5150)