### PR TITLE
Support command arguments for VisualEditing

### DIFF
--- a/PSReadLine/VisualEditing.vi.cs
+++ b/PSReadLine/VisualEditing.vi.cs
@@ -16,15 +16,51 @@ namespace Microsoft.PowerShell
         /// </summary>
         public static void ViEditVisually(ConsoleKeyInfo? key = null, object arg = null)
         {
-            string editor = GetPreferredEditor();
-            if (string.IsNullOrWhiteSpace(editor))
+            // EDITOR can be a cmd with args such as `emacsclient -c`
+            // each component of the cmd may only be quoted by " due to internal design, see doc for `ProcessStartInfo.Arguments`
+            string cmd = GetPreferredEditor().Trim();
+
+            if (string.IsNullOrEmpty(cmd))
             {
                 Ding();
                 return;
             }
 
-            if (!(_singleton._engineIntrinsics?.InvokeCommand.GetCommand(editor, CommandTypes.Application) is
-                ApplicationInfo editorCommand))
+            string exe = string.Empty;
+            string arguments = string.Empty;
+            bool exeQuoteUnmatched = false;
+
+            if (File.Exists(cmd)) // path/might contain space/foo.exe
+            {
+                exe = cmd;
+            }
+            else if (cmd.StartsWith('"')) // "path/with space/foo.exe" --args ...
+            {
+                int nextQuote = cmd.IndexOf('"', 1);
+
+                if (nextQuote != -1)
+                    (exe, arguments) = (cmd[1..nextQuote], cmd[(nextQuote + 1)..]);
+                else
+                    exeQuoteUnmatched = true;
+            }
+            else
+            {
+                // foo.exe
+                // foo.exe --args
+                // path/to/foo.exe --args
+                int firstSpace = cmd.IndexOf(' ');
+                (exe, arguments) = firstSpace != -1
+                    ? (cmd[..firstSpace], cmd[(firstSpace + 1)..])
+                    : (cmd, string.Empty);
+            }
+
+            if (string.IsNullOrEmpty(exe) || exeQuoteUnmatched)
+            {
+                Ding();
+                return;
+            }
+
+            if (_singleton._engineIntrinsics?.InvokeCommand.GetCommand(exe, CommandTypes.Application) is not ApplicationInfo editorCommand)
             {
                 Ding();
                 return;
@@ -39,8 +75,8 @@ namespace Microsoft.PowerShell
                 }
             }
 
-            editor = editorCommand.Path;
-            var si = new ProcessStartInfo(editor, $"\"{tempPowerShellFile}\"")
+            exe = editorCommand.Path;
+            var si = new ProcessStartInfo(exe, $"{arguments} \"{tempPowerShellFile}\"")
             {
                 UseShellExecute = false,
                 RedirectStandardError = false,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Resolves #3214

Bash readline supports `$EDITOR` with command arguments, I wish to have this in PSReadLine as well.

```sh
export EDITOR='nvim --cmd "lua vim.env.foo = 1"'
```

```ps1
$env:EDITOR = 'nvim --cmd "lua vim.env.foo = 1"'
```

This change adds following possible patterns for visual editor:
1. `path/to/foo.exe --args`
2. `"path/with space/foo.exe" --args`
3. `foo.exe --args`

Note that `ProcessStartInfo.Arguments` only allows `"` for quoting components, which is different from bash, this worth to be mentioned in documentation.
I didn't add test since I neither found an existing test for `ViEditVisually` nor am familiar enough with this repository to write from scratch.

## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [x] Summarized changes
- [ ] Make sure you've added one or more new tests
- [x] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [x] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/5174)