### PR TITLE
Better default syntax colors

### DIFF
--- a/PSReadLine/Cmdlets.cs
+++ b/PSReadLine/Cmdlets.cs
@@ -82,14 +82,14 @@ namespace Microsoft.PowerShell
     public class PSConsoleReadLineOptions
     {
         public const ConsoleColor DefaultCommentColor   = ConsoleColor.DarkGreen;
-        public const ConsoleColor DefaultKeywordColor   = ConsoleColor.Green;
-        public const ConsoleColor DefaultStringColor    = ConsoleColor.DarkCyan;
-        public const ConsoleColor DefaultOperatorColor  = ConsoleColor.DarkGray;
+        public const ConsoleColor DefaultKeywordColor   = ConsoleColor.Magenta;
+        public const ConsoleColor DefaultStringColor    = ConsoleColor.Green;
+        public const ConsoleColor DefaultOperatorColor  = ConsoleColor.Cyan;
         public const ConsoleColor DefaultVariableColor  = ConsoleColor.Green;
-        public const ConsoleColor DefaultCommandColor   = ConsoleColor.Yellow;
-        public const ConsoleColor DefaultParameterColor = ConsoleColor.DarkGray;
-        public const ConsoleColor DefaultTypeColor      = ConsoleColor.Gray;
-        public const ConsoleColor DefaultNumberColor    = ConsoleColor.White;
+        public const ConsoleColor DefaultCommandColor   = ConsoleColor.Blue;
+        public const ConsoleColor DefaultParameterColor = ConsoleColor.Magenta;
+        public const ConsoleColor DefaultTypeColor      = ConsoleColor.Cyan;
+        public const ConsoleColor DefaultNumberColor    = ConsoleColor.Yellow;
         public const ConsoleColor DefaultMemberColor    = ConsoleColor.Gray;
         public const ConsoleColor DefaultEmphasisColor  = ConsoleColor.Cyan;
         public const ConsoleColor DefaultErrorColor     = ConsoleColor.Red;


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

1. `String`: `DarkCyan` -> `Green`, as green is more intuitive color for string
1. `Keyword`: `Green` -> `Magenta`, as keyword is not string
1. `Type`: `Gray` -> `Cyan`, make it colorful
1. `Operator`: `DarkGray` -> `Cyan`, as `Operator` are generally not right next to `Type`
1. `Command`: `Yellow` -> `Blue`, as main color of pwsh icon is blue
1. `Number`: `White` -> `Yellow`, number should be distinct from the default symbol interpretation(into string)
1. `Parameter`: `DarkGray` -> `Magenta`, make it distinct, related: #5169

Before:

<img width="805" height="59" alt="image" src="https://github.com/user-attachments/assets/868213d5-a593-425b-acf0-8e1fcd3f5bd2" />

After:

<img width="803" height="60" alt="image" src="https://github.com/user-attachments/assets/7ce6fc09-1766-49ea-bde7-943264b59737" />


## PR Checklist

- [x] PR has a meaningful title
    - Use the present tense and imperative mood when describing your changes
- [ ] Summarized changes
- [ ] Make sure you've added one or more new tests
- [ ] Make sure you've tested these changes in terminals that PowerShell is commonly used in (i.e. conhost.exe, Windows Terminal, Visual Studio Code Integrated Terminal, etc.)
- **User-facing changes**
    - [ ] Not Applicable
    - **OR**
    - [ ] Documentation needed at [PowerShell-Docs](https://github.com/MicrosoftDocs/PowerShell-Docs)
        - [ ] Doc Issue filed: <!-- Number/link of that issue here -->

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/PowerShell/PSReadLine/pull/5175)